### PR TITLE
add contribution infrastructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global Codeowners
+*  @devmil @adamgic

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior, e.g.:
+- involved package refs (that would be ideal)
+- link to branch of the package that causes the issue (if possible)
+
+**Actual and Expected behavior**
+A clear and concise description of what you expected to happen and what actually happened.
+
+**System info (please complete the following information):**
+ - Output of `dart --version`
+ - dart_apitool version (`dart-apitool --version`)
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--
+  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
+  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
+-->
+
+## Description
+<!--- Describe your change. Put something useful here. Not just `I changed stuff`. -->
+
+## Type of Change
+<!--- Put an 'x' in all boxes which apply -->
+
+- [ ] 🚀 New feature (non-breaking change)
+- [ ] 🛠️ Bug fix (non-breaking change)
+- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
+- [ ] 🏗️ Code refactor
+- [ ] ⚙️ Build configuration change
+- [ ] 📝 Documentation
+- [ ] 🧹 Chore / Housekeeping

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+flutter-dev@bmwgroup.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Welcome to dart_apitool contributing guide
+
+Thank you for investing your time in contributing to our project!
+
+To start off, read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectable.
+
+In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+
+### Getting started
+
+To get an overview of the project, read the [README](README.md).
+
+### Did you find a bug?
+
+If you spot a problem with dart_apitool, ensure that the bug was not already reported by searching on GitHub under [Issues](https://github.com/bmw-tech/dart_apitool/issues).  
+[Here](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments) is a guide for how to search effectively on GitHub.
+
+If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/bmw-tech/dart_apitool/issues/new?assignees=&labels=bug&template=bug_report.md&title=). Be sure to include a title and a clear description, as much relevant information as possible.
+
+### Do you want to solve an issue
+
+Scan through our [existing issues](https://github.com/bmw-tech/dart_apitool/issues) to find one that interests you. You can narrow down the search using `labels` as filters. If you are only interested in solving bugs then please check out [all our open bugs](https://github.com/bmw-tech/dart_apitool/labels/bug).
+
+If you find an issue to work on, you are more than welcome to open a PR with a fix.
+
+### Did you write code that fixes an issue?
+
+* Once you think you're done coding, open a new pull request. Target the `main` branch. We are doing trunk based development.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+* Once the pipeline becomes green and you have the required review approvals, then feel free to squash and merge your PR.
+
+
+### Do you intend to add a new feature or change an existing one?
+
+Check out the [existing enhancement issues](https://github.com/bmw-tech/dart_apitool/labels/enhancement) and make sure that a similar suggestion does not already exist.
+
+If you're unable to find an open issue addressing the suggestion, [open a new one](https://github.com/bmw-tech/dart_apitool/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=). Be sure to include as much relevant information as possible.
+
+We will try to comment and give you feedback on your suggestion as a soon as possible. If you're excited about your idea and cannot wait for feedback to start, then feel free to start coding right away.  
+But please note that we cannot guarantee that your suggestion will be accepted.
+
+### Thanks! ❤️ ❤️ ❤️
+
+Thanks again for investing your time in contributing to our project!

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -45,9 +45,16 @@ dart-apitool (${Colorize(await _getOwnVersion()).bold()})
 
 A set of utilities for Package APIs.
 ''')
+    ..argParser.addFlag('version',
+        abbr: 'v', help: 'Prints the version of this tool.', negatable: false)
     ..addCommand(DiffCommand())
     ..addCommand(ExtractCommand());
   try {
+    final argParseResult = runner.argParser.parse(arguments);
+    if (argParseResult['version']) {
+      print(await _getOwnVersion());
+      exit(0);
+    }
     final exitCode = await runner.run(arguments);
     exit(exitCode ?? -1);
   } catch (e) {


### PR DESCRIPTION
This PR copies the contribution infrastructure from widget_driver:
- issue templates
- pull request template
- code of conduct
- contribution guide
- code owners