### PR TITLE
fix!: Improves handling of pre-release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Version 0.12.2
+## Version 0.13.0
+- default behavior of `--ignore-prerelease` is now `on`
+- improved pre-release handling. Now dart_apitool plays well in scenarios where released pre-release versions are compared to the new stable release
 - fall back to system Flutter executable if no matching Flutter executable can be found
 
 ## Version 0.12.1

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Usage: dart-apitool diff [arguments]
                                          [none, fully (default), onlyBreakingChanges]
     --[no-]check-sdk-version             Determines if the SDK version should be checked.
                                          (defaults to on)
-    --[no-]ignore-prerelease             Determines if the pre-release aspect of the version
+    --[no-]ignore-prerelease             Determines if the pre-release aspect of the new version
                                          shall be ignored when checking versions.
                                          This only makes sense in combination with --dependency-check-mode != none.
                                          You may want to do this if you want to make sure
                                          (in your CI) that the version - once ready - matches semver.
+                                         (defaults to on)
     --no-merge-base-classes              Disables base class merging.
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
     --dependency-check-mode              Defines the mode package dependency changes are handled.

--- a/lib/src/cli/commands/version_check.dart
+++ b/lib/src/cli/commands/version_check.dart
@@ -1,0 +1,117 @@
+import 'dart:io';
+
+import 'package:colorize/colorize.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import '../../../api_tool.dart';
+
+/// helper class to check if the version change matches the changes
+abstract class VersionCheck {
+  /// checks if the version change between [oldPackageApi] and [newPackageApi] matches the changes in [diffResult]
+  static bool versionChangeMatchesChanges({
+    required PackageApiDiffResult diffResult,
+    required PackageApi oldPackageApi,
+    required PackageApi newPackageApi,
+    required bool ignorePrerelease,
+    required VersionCheckMode versionCheckMode,
+  }) {
+    stdout.writeln('');
+    stdout.writeln('Checking Package version');
+    stdout.writeln('');
+    if (oldPackageApi.packageVersion == null) {
+      throw PackageApiDiffError(
+          message: 'Old package doesn\'t contain a version]');
+    }
+    if (newPackageApi.packageVersion == null) {
+      throw PackageApiDiffError(
+          message: 'New package doesn\'t contain a version]');
+    }
+    final oldVersion = Version.parse(oldPackageApi.packageVersion!);
+    final newVersion = Version.parse(newPackageApi.packageVersion!);
+
+    bool containsAnyChanges = diffResult.hasChanges;
+    bool containsBreakingChanges =
+        diffResult.apiChanges.any((change) => change.isBreaking);
+    bool onlyPatchChanges =
+        diffResult.apiChanges.any((change) => !change.type.requiresMinorBump);
+
+    if (versionCheckMode == VersionCheckMode.none) {
+      stdout.writeln('Skipping version check completely');
+      return true;
+    }
+    if (versionCheckMode == VersionCheckMode.onlyBreakingChanges &&
+        !containsBreakingChanges) {
+      stdout.writeln(
+          'Skipping version check because there are no breaking changes');
+      return true;
+    }
+
+    if (ignorePrerelease) {
+      // if we want to ignore pre-release then we just remove the prerelease part of the Version
+      stdout.writeln('ignoring prerelease');
+      newVersion.preRelease.clear();
+    }
+
+    if (oldVersion.isPreRelease) {
+      // if the old version is a prerelease version then we test if the new version is the same without the prerelease part
+      final oldVersionWithoutPreRelease = Version.parse(oldVersion.toString());
+      oldVersionWithoutPreRelease.preRelease.clear();
+      if (oldVersionWithoutPreRelease <= newVersion) {
+        stdout.writeln(
+            'Skipping version check because the old version is a pre-release and the new version is the same or higher without the pre-release part');
+        return true;
+      }
+    }
+
+    if (newVersion.isPreRelease) {
+      // pre-release. We don't look at differentiation between breaking and non-breaking changes
+      stdout.writeln(
+          'We got a pre release. We only check if there are any changes');
+      if (containsAnyChanges && oldVersion >= newVersion) {
+        stdout.writeln(
+            'Got "${Colorize(newVersion.toString()).bold()}" expected > "${Colorize(oldVersion.toString()).bold()}" (pre-release but changes)');
+        return false;
+      }
+      stdout.writeln(Colorize('New version is OK!').green());
+      final explaination = containsAnyChanges
+          ? 'which is > "${Colorize(oldVersion.toString()).bold()}" (pre-release but changes)'
+          : 'and no changes';
+      stdout.writeln(
+          'Got "${Colorize(newVersion.toString()).bold()}" $explaination');
+      return true;
+    }
+
+    Version expectedMinVersion =
+        containsAnyChanges ? oldVersion.nextPatch : oldVersion;
+    String versionExplanation = 'no changes';
+    if (containsBreakingChanges) {
+      expectedMinVersion = oldVersion.nextBreaking;
+      versionExplanation = 'breaking changes';
+    } else if (containsAnyChanges) {
+      if (!onlyPatchChanges) {
+        // Only for major > 0: expect the minor version to be incremented if any changes in the public API happen
+        if (oldVersion.major > 0) {
+          expectedMinVersion = oldVersion.nextMinor;
+        }
+        versionExplanation = 'non-breaking changes';
+      } else {
+        versionExplanation = 'non-breaking changes --> patch';
+      }
+    }
+
+    stdout.writeln('Old version: "$oldVersion"');
+    stdout.writeln(
+        'Expecting minimum version: "$expectedMinVersion" ($versionExplanation)');
+    if (newVersion < expectedMinVersion) {
+      stdout.writeln(Colorize('New Version is too low!').red());
+      stdout.writeln(
+          'Got "${Colorize(newVersion.toString()).bold()}" expected >= "${Colorize(expectedMinVersion.toString()).bold()}"');
+      return false;
+    } else {
+      stdout.writeln(Colorize('New version is OK!').green());
+      stdout.writeln(
+          'Got "${Colorize(newVersion.toString()).bold()}" which is >= "${Colorize(expectedMinVersion.toString()).bold()}"');
+      return true;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.12.2-dev
+version: 0.13.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/test/unit_tests/cli/commands/version_check_test.dart
+++ b/test/unit_tests/cli/commands/version_check_test.dart
@@ -1,0 +1,164 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:dart_apitool/src/cli/commands/version_check.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  PackageApi createTestPackageApi({
+    required String packageVersion,
+    SdkType sdkType = SdkType.flutter,
+  }) {
+    return PackageApi(
+      packageName: 'test_package',
+      packageVersion: packageVersion,
+      packagePath: 'test_package',
+      interfaceDeclarations: [],
+      executableDeclarations: [],
+      fieldDeclarations: [],
+      typeAliasDeclarations: [],
+      sdkType: sdkType,
+      packageDependencies: [],
+      minSdkVersion: Version.parse('2.10.5'),
+    );
+  }
+
+  PackageApiDiffResult createDiffResult(
+      {List<ApiChangeType> changeTypes = const []}) {
+    final result = PackageApiDiffResult();
+    for (final ct in changeTypes) {
+      result.apiChanges.add(ApiChange(
+        type: ct,
+        changeCode: ApiChangeCode.cd01,
+        changeDescription: '',
+        contextTrace: [],
+        isExperimental: false,
+      ));
+    }
+    return result;
+  }
+
+  group('Version Check', () {
+    test('is fine with breaking change and major version change', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.0.0'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test('is NOT fine with breaking change and minor version change', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '1.1.0'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isFalse);
+    });
+    test('is fine with non-breaking change and minor version change', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult:
+            createDiffResult(changeTypes: [ApiChangeType.addCompatibleMinor]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '1.1.0'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test('is NOT fine with non-breaking change and patch version change', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult:
+            createDiffResult(changeTypes: [ApiChangeType.addCompatibleMinor]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '1.0.1'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isFalse);
+    });
+    test('is fine with non-breaking (patch) change and patch version change',
+        () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult:
+            createDiffResult(changeTypes: [ApiChangeType.addCompatiblePatch]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '1.0.1'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test('is fine with non-breaking (patch) change and minor version change',
+        () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult:
+            createDiffResult(changeTypes: [ApiChangeType.addCompatiblePatch]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '1.1.0'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test('is fine with non-breaking (patch) change and major version change',
+        () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult:
+            createDiffResult(changeTypes: [ApiChangeType.addCompatiblePatch]),
+        oldPackageApi: createTestPackageApi(packageVersion: '1.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.0.0'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test(
+        'is fine with breaking change and only prerelease tag in version change',
+        () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '2.0.0-dev01'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.0.1'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test('ignores prerelease tag if ignorePrerelease is set', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '2.0.0'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.1.0-dev01'),
+        ignorePrerelease: true,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isFalse);
+    });
+    test('if old and new version have prerelease set, nothing matters', () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '2.0.0-dev00'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.1.0-dev01'),
+        ignorePrerelease: false,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isTrue);
+    });
+    test(
+        'if old and new version have prerelease set, the base version still has to be the same or higher for the new package',
+        () {
+      bool versionChangeCheckResult = VersionCheck.versionChangeMatchesChanges(
+        diffResult: createDiffResult(changeTypes: [ApiChangeType.addBreaking]),
+        oldPackageApi: createTestPackageApi(packageVersion: '2.1.0-dev00'),
+        newPackageApi: createTestPackageApi(packageVersion: '2.0.0-dev01'),
+        ignorePrerelease: false,
+        versionCheckMode: VersionCheckMode.fully,
+      );
+      expect(versionChangeCheckResult, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR fixes pre-release handling in dart_apitool.
Now also pre-release tags of the old version are taken into account and loosen the requirements for the new version.

**Breaking change**: the default for `--ignore-prerelease` is now `on`.

Fixes #117

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
