### PR TITLE
fix: Enum constructors and overrides of object defined elements should not be public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Version 0.14.0
-- improves change type detection for parameter type changes
+- improves change type detection for parameter type changes (widening types is now considered non-breaking)
+- ignores enum constructors and Object elements (toString and hashCode) as they are not relevant for the API
 
 ## Version 0.13.0
 - fixes an issue with required interface detection on property and field usage

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -177,9 +177,30 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   }
 
   bool _isElementAllowedToBeCollected(Element element) {
+    // here we filter out elements that are technically part of the public API but actually aren't
+    // either because they can not be used (like Enum constructors) or are present via the Object base class anyways
+    if (element is ConstructorElement) {
+      // constructors of enums aren't collected
+      if (element.enclosingElement is EnumElement) {
+        return false;
+      }
+    } else if (element is MethodElement) {
+      // don't collect toString of Objects
+      if (element.name == 'toString' && element.parameters.isEmpty) {
+        return false;
+      }
+    } else if (element is FieldElement) {
+      // don't collect hashCode of Objects
+      if (element.name == 'hashCode') {
+        return false;
+      }
+    }
+
+    // if the element is public, it is allowed to be collected
     if (element.isPublic) {
       return true;
     }
+    // only collect explicitly allowed private elements (are used somewhere and therefore implicitly public)
     return privateElementExceptions.contains(element.id);
   }
 

--- a/test/integration_tests/diff/enum_ctor_and_tostring_test.dart
+++ b/test/integration_tests/diff/enum_ctor_and_tostring_test.dart
@@ -1,0 +1,78 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('enum ctor and toString', () {
+    late PackageApiAnalyzer packageAWithEnumCtorAndToString;
+    late PackageApiAnalyzer packageAWithoutEnumCtorAndToString;
+
+    setUpAll(
+      () {
+        packageAWithEnumCtorAndToString = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'enum_and_tostring',
+          'package_a_with_enum_ctor_and_tostring',
+        ));
+        packageAWithoutEnumCtorAndToString = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'enum_and_tostring',
+          'package_a_without_enum_ctor_and_tostring',
+        ));
+      },
+    );
+
+    group('removing ctor and toString', () {
+      late PackageApiDiffResult diffResult;
+      setUp(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageAWithEnumCtorAndToString.analyze(),
+          newApi: await packageAWithoutEnumCtorAndToString.analyze(),
+        );
+      });
+      test('making enum ctor private is no change at all', () {
+        expect(
+            diffResult.apiChanges
+                .where((c) => c.changeDescription.contains('EnumA'))
+                .isEmpty,
+            isTrue);
+      });
+      test('removing toString is no breaking change', () {
+        expect(
+            diffResult.apiChanges
+                .where((c) =>
+                    c.changeDescription.contains('toString') && c.isBreaking)
+                .isEmpty,
+            isTrue);
+      });
+    });
+    group('adding ctor and toString', () {
+      late PackageApiDiffResult diffResult;
+      setUp(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageAWithoutEnumCtorAndToString.analyze(),
+          newApi: await packageAWithEnumCtorAndToString.analyze(),
+        );
+      });
+      test('making enum ctor public is no change at all', () {
+        expect(
+            diffResult.apiChanges
+                .where((c) => c.changeDescription.contains('EnumA'))
+                .isEmpty,
+            isTrue);
+      });
+      test('adding toString is no breaking change', () {
+        expect(
+            diffResult.apiChanges
+                .where((c) =>
+                    c.changeDescription.contains('toString') && c.isBreaking)
+                .isEmpty,
+            isTrue);
+      });
+    });
+  });
+}

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/.gitignore
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/CHANGELOG.md
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/README.md
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/analysis_options.yaml
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/package_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/package_a.dart
@@ -1,0 +1,7 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library package_a;
+
+export 'src/class_a.dart';
+export 'src/enum_a.dart';

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/src/class_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/src/class_a.dart
@@ -1,0 +1,9 @@
+class ClassA {
+  final String someValue;
+  const ClassA(this.someValue);
+
+  @override
+  String toString() {
+    return 'ClassA{someValue: $someValue}';
+  }
+}

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/src/enum_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/lib/src/enum_a.dart
@@ -1,0 +1,1 @@
+enum EnumA { val1, val2, val3 }

--- a/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/pubspec.yaml
+++ b/test/test_packages/enum_and_tostring/package_a_with_enum_ctor_and_tostring/pubspec.yaml
@@ -1,0 +1,14 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies: 
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/.gitignore
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/CHANGELOG.md
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/README.md
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/analysis_options.yaml
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/package_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/package_a.dart
@@ -1,0 +1,7 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library package_a;
+
+export 'src/class_a.dart';
+export 'src/enum_a.dart';

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/class_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/class_a.dart
@@ -1,0 +1,4 @@
+class ClassA {
+  final String someValue;
+  const ClassA(this.someValue);
+}

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/enum_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/enum_a.dart
@@ -1,0 +1,9 @@
+enum EnumA {
+  val1(1),
+  val2(2),
+  val3(3);
+
+  const EnumA._(this.val)
+
+  final int val;
+}

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/enum_a.dart
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/lib/src/enum_a.dart
@@ -3,7 +3,7 @@ enum EnumA {
   val2(2),
   val3(3);
 
-  const EnumA._(this.val)
+  const EnumA._(this.val);
 
   final int val;
 }

--- a/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/pubspec.yaml
+++ b/test/test_packages/enum_and_tostring/package_a_without_enum_ctor_and_tostring/pubspec.yaml
@@ -1,0 +1,14 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.1.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.21.0


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
This PR filters enum constructors and `toString()` + `hashCode` from the analyzed public API as those have no relevance regarding public API changes.

Fixes #126 
Fixes #125 

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
