### PR TITLE
chore: replaces apiChange length check + any expectation with containsOnce + predicate

### DIFF
--- a/test/integration_tests/diff/test_package_experimental_test.dart
+++ b/test/integration_tests/diff/test_package_experimental_test.dart
@@ -35,31 +35,35 @@ void main() {
       });
 
       test('detects removal of experimental flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassA' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassA' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'name' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'name' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'getName' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'getName' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });
@@ -73,31 +77,35 @@ void main() {
       });
 
       test('detects addition of experimental flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassA' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassA' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'name' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'name' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'getName' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'getName' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });

--- a/test/integration_tests/diff/test_package_sealed_test.dart
+++ b/test/integration_tests/diff/test_package_sealed_test.dart
@@ -35,24 +35,26 @@ void main() {
       });
 
       test('detects removal of sealed flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassD' &&
-                element.changeDescription.contains('Sealed') &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassD' &&
+                  change.changeDescription.contains('Sealed') &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'newMethod' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'newMethod' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });
@@ -66,24 +68,26 @@ void main() {
       });
 
       test('detects addition of sealed flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + add method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassD' &&
-                element.changeDescription.contains('Sealed') &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassD' &&
+                  change.changeDescription.contains('Sealed') &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'newMethod' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'newMethod' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
This PR makes some unit test cleanup as suggested in #132 

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
