### PR TITLE
add unexported interfaces check

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.7.7",
+  "flutterSdkVersion": "3.7.8",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - improves change type detection for parameter type changes (widening types is now considered non-breaking)
 - ignores enum constructors and elements marked with @override
 - detects @sealed classes and doesn't consider them as required interfaces
+- removes '[no]-merge-base-classes' option as this functionality is crucial now
+- improved entry point tracking
+- warning if a root level type is part of the public API but not exported
 
 ## Version 0.13.0
 - fixes an issue with required interface detection on property and field usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - removes '[no]-merge-base-classes' option as this functionality is crucial now
 - improved entry point tracking
 - warning if a root level type is part of the public API but not exported
+  - can be turned into an error with `--[no-]set-exit-on-missing-export`
 
 ## Version 0.13.0
 - fixes an issue with required interface detection on property and field usage

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Usage: dart-apitool extract [arguments]
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
     --[no-]remove-example                Removes examples from the package to analyze.
                                          (defaults to on)
+    --[no-]set-exit-on-missing-export    Sets exit code to != 0 if missing exports are detected in the API.
 ```
 
 ### diff

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Usage: dart-apitool extract [arguments]
                                          (defaults to off)
     --output                             Output file for the extracted Package API.
                                          If not specified the extracted API will be printed to the console.
-    --no-merge-base-classes              Disables base class merging.
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
     --[no-]remove-example                Removes examples from the package to analyze.
                                          (defaults to on)
@@ -95,7 +94,6 @@ Usage: dart-apitool diff [arguments]
                                          You may want to do this if you want to make sure
                                          (in your CI) that the version - once ready - matches semver.
                                          (defaults to on)
-    --no-merge-base-classes              Disables base class merging.
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
     --dependency-check-mode              Defines the mode package dependency changes are handled.
                                          [none, allowAdding, strict (default)]

--- a/lib/api_tool.dart
+++ b/lib/api_tool.dart
@@ -4,3 +4,4 @@ export 'src/storage/storage.dart';
 export 'src/tooling/tooling.dart';
 export 'src/diff/diff.dart';
 export 'src/errors/errors.dart';
+export 'src/utils/utils.dart';

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -66,7 +66,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   final List<InternalExecutableDeclaration> _executableDeclarations = [];
   final List<InternalFieldDeclaration> _fieldDeclarations = [];
   final List<InternalTypeAliasDeclaration> _typeAliasDeclarations = [];
-  final Set<int> _requiredElementIds = {};
+  final Map<int, Set<TypeUsage>> typeUsages = {};
   final TypeHierarchy typeHierarchy;
 
   /// all found class declarations
@@ -84,22 +84,20 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   List<InternalTypeAliasDeclaration> get typeAliasDeclarations =>
       _typeAliasDeclarations;
 
-  /// all element ids that are used in a required context (e.g. implementable / extendable by the user)
-  Set<int> get requiredElementIds => _requiredElementIds;
-
   /// list of element ids that are allowed to be collected even if they are private
   final List<int> privateElementExceptions;
 
   void _onTypeUsed(DartType type, Element referringElement,
-      {required bool isRequired}) {
+      {required TypeUsage typeUsage}) {
     final directElement = type.element2;
     final directElementLibrary = directElement?.library;
     if (directElement == null || directElementLibrary == null) {
       return;
     }
-    if (isRequired) {
-      _requiredElementIds.add(directElement.id);
+    if (!typeUsages.containsKey(directElement.id)) {
+      typeUsages[directElement.id] = {};
     }
+    typeUsages[directElement.id]!.add(typeUsage);
     if (_collectedElementIds.contains(directElement.id)) {
       return;
     }
@@ -125,18 +123,31 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       executableDeclarations.addAll(collector.executableDeclarations);
       fieldDeclarations.addAll(collector.fieldDeclarations);
       typeAliasDeclarations.addAll(collector.typeAliasDeclarations);
-      _requiredElementIds.addAll(collector.requiredElementIds);
+      for (final tu in collector.typeUsages.entries) {
+        if (!typeUsages.containsKey(tu.key)) {
+          typeUsages[tu.key] = {};
+        }
+        typeUsages[tu.key]!.addAll(tu.value);
+      }
     }
     if (type is InterfaceType) {
       for (final ta in type.typeArguments) {
         if (ta is InterfaceType) {
-          _onTypeUsed(ta, referringElement, isRequired: false);
+          _onTypeUsed(
+            ta,
+            referringElement,
+            typeUsage: TypeUsage.hierarchy,
+          );
         }
       }
     } else if (type is TypeAlias) {
       final aliasedType = type.alias?.element.aliasedType;
       if (aliasedType != null) {
-        _onTypeUsed(aliasedType, referringElement, isRequired: false);
+        _onTypeUsed(
+          aliasedType,
+          referringElement,
+          typeUsage: TypeUsage.hierarchy,
+        );
       }
     }
   }
@@ -232,7 +243,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     ));
     for (final st in interfaceElement.allSupertypes) {
       if (!st.isDartCoreObject && !st.isDartCoreEnum) {
-        _onTypeUsed(st, interfaceElement, isRequired: false);
+        _onTypeUsed(st, interfaceElement, typeUsage: TypeUsage.hierarchy);
       }
     }
     return true;
@@ -278,7 +289,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
           !element.isConst &&
           !element.isPrivate &&
           element.setter != null;
-      _onTypeUsed(element.type, element, isRequired: canBeSet);
+      _onTypeUsed(element.type, element, typeUsage: TypeUsage.output);
+      if (canBeSet) {
+        _onTypeUsed(element.type, element, typeUsage: TypeUsage.input);
+      }
     }
   }
 
@@ -300,7 +314,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     if (element.type.element2 != null) {
       bool canBeSet =
           !element.isFinal && !element.isConst && !element.isPrivate;
-      _onTypeUsed(element.type, element, isRequired: canBeSet);
+      _onTypeUsed(element.type, element, typeUsage: TypeUsage.output);
+      if (canBeSet) {
+        _onTypeUsed(element.type, element, typeUsage: TypeUsage.input);
+      }
     }
   }
 
@@ -314,7 +331,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     }
     // this includes method, function and constructor calls
     if (element.type.element2 != null) {
-      _onTypeUsed(element.type, element, isRequired: true);
+      _onTypeUsed(element.type, element, typeUsage: TypeUsage.input);
     }
   }
 
@@ -334,7 +351,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     ));
     super.visitMethodElement(element);
     if (element.returnType.element2 != null) {
-      _onTypeUsed(element.returnType, element, isRequired: false);
+      _onTypeUsed(element.returnType, element, typeUsage: TypeUsage.output);
     }
   }
 
@@ -355,7 +372,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     ));
     super.visitFunctionElement(element);
     if (element.returnType.element2 != null) {
-      _onTypeUsed(element.returnType, element, isRequired: false);
+      _onTypeUsed(element.returnType, element, typeUsage: TypeUsage.output);
     }
   }
 
@@ -395,7 +412,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     ));
     super.visitTypeAliasElement(element);
     if (element.aliasedType.element2 != null) {
-      _onTypeUsed(element.aliasedType, element, isRequired: false);
+      _onTypeUsed(element.aliasedType, element, typeUsage: TypeUsage.hierarchy);
     }
   }
 
@@ -404,7 +421,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
     _onVisitAnyElement(element);
     super.visitTypeParameterElement(element);
     if (element.bound?.element2 != null) {
-      _onTypeUsed(element.bound!, element, isRequired: false);
+      _onTypeUsed(element.bound!, element, typeUsage: TypeUsage.hierarchy);
     }
   }
 
@@ -427,7 +444,8 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
       rootPath: _context.rootPath,
     ));
     if (element.extendedType.element2 != null) {
-      _onTypeUsed(element.extendedType, element, isRequired: false);
+      _onTypeUsed(element.extendedType, element,
+          typeUsage: TypeUsage.hierarchy);
     }
 
     super.visitExtensionElement(element);

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -54,6 +54,10 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   }
 
   late final Set<int> _collectedElementIds;
+
+  /// [directlyCollectedElementIds] is the set of element ids that are directly collected by this visitor
+  Set<int> directlyCollectedElementIds = {};
+
   final _AnalysisContext _context;
 
   String? _packageName;
@@ -201,6 +205,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor<void> {
   /// marks the given element as collected.
   /// Returns [true] if it got marked, returns [false] if it is already marked as collected
   bool _markElementAsCollected(Element element) {
+    directlyCollectedElementIds.add(element.id);
     if (_collectedElementIds.contains(element.id)) {
       return false;
     }

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -6,7 +6,6 @@ import 'package:dart_apitool/src/cli/source_item.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-import '../../utils/utils.dart';
 import '../package_ref.dart';
 import '../prepared_package_ref.dart';
 
@@ -102,7 +101,6 @@ Affects only local references.
   /// [doAnalyzePlatformConstraints] defines if the platform constraints of the package shall be analyzed.
   Future<PackageApi> analyze(
     PreparedPackageRef preparedRef, {
-    bool doMergeBaseClasses = true,
     bool doAnalyzePlatformConstraints = true,
     bool doRemoveExample = true,
   }) async {
@@ -138,7 +136,6 @@ Affects only local references.
     stdoutSession.writeln('Analyzing $path');
     final analyzer = PackageApiAnalyzer(
       packagePath: packagePath,
-      doMergeBaseClasses: doMergeBaseClasses,
       doAnalyzePlatformConstraints: doAnalyzePlatformConstraints,
     );
     return await analyzer.analyze();

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -14,7 +14,6 @@ String _optionNameNew = 'new';
 String _optionNameIncludePathDependencies = 'include-path-dependencies';
 String _optionNameVersionCheckMode = 'version-check-mode';
 String _optionNameIgnorePrerelease = 'ignore-prerelease';
-String _optionNameNoMergeBaseClasses = 'no-merge-base-classes';
 String _optionNameNoAnalyzePlatformConstraints =
     'no-analyze-platform-constraints';
 String _optionNameCheckSdkVersion = 'check-sdk-version';
@@ -72,12 +71,6 @@ You may want to do this if you want to make sure
       negatable: true,
     );
     argParser.addFlag(
-      _optionNameNoMergeBaseClasses,
-      help: 'Disables base class merging.',
-      defaultsTo: false,
-      negatable: false,
-    );
-    argParser.addFlag(
       _optionNameNoAnalyzePlatformConstraints,
       help: 'Disables analysis of platform constraints.',
       defaultsTo: false,
@@ -107,8 +100,6 @@ You may want to do this if you want to make sure
         (element) => element.name == argResults![_optionNameVersionCheckMode]);
     final ignorePrerelease = argResults![_optionNameIgnorePrerelease] as bool;
     final doCheckSdkVersion = argResults![_optionNameCheckSdkVersion] as bool;
-    final noMergeBaseClasses =
-        argResults![_optionNameNoMergeBaseClasses] as bool;
     final noAnalyzePlatformConstraints =
         argResults![_optionNameNoAnalyzePlatformConstraints] as bool;
     final dependencyCheckMode = DependencyCheckMode.values.firstWhere(
@@ -127,13 +118,11 @@ You may want to do this if you want to make sure
 
     final oldPackageApi = await analyze(
       preparedOldPackageRef,
-      doMergeBaseClasses: !noMergeBaseClasses,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,
     );
     final newPackageApi = await analyze(
       preparedNewPackageRef,
-      doMergeBaseClasses: !noMergeBaseClasses,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,
     );

--- a/lib/src/cli/commands/extract_command.dart
+++ b/lib/src/cli/commands/extract_command.dart
@@ -9,7 +9,6 @@ import 'command_mixin.dart';
 String _optionNameInput = 'input';
 String _optionNameIncludePathDependencies = 'include-path-dependencies';
 String _optionNameOutput = 'output';
-String _optionNameNoMergeBaseClasses = 'no-merge-base-classes';
 String _optionNameNoAnalyzePlatformConstraints =
     'no-analyze-platform-constraints';
 String _optionNameRemoveExample = 'remove-example';
@@ -42,12 +41,6 @@ If not specified the extracted API will be printed to the console.
 ''',
     );
     argParser.addFlag(
-      _optionNameNoMergeBaseClasses,
-      help: 'Disables base class merging.',
-      defaultsTo: false,
-      negatable: false,
-    );
-    argParser.addFlag(
       _optionNameNoAnalyzePlatformConstraints,
       help: 'Disables analysis of platform constraints.',
       defaultsTo: false,
@@ -66,8 +59,6 @@ If not specified the extracted API will be printed to the console.
     final packageRef = PackageRef(argResults![_optionNameInput]);
     final shouldCheckPathDependencies =
         argResults![_optionNameIncludePathDependencies] as bool;
-    final noMergeBaseClasses =
-        argResults![_optionNameNoMergeBaseClasses] as bool;
     final noAnalyzePlatformConstraints =
         argResults![_optionNameNoAnalyzePlatformConstraints] as bool;
     final doRemoveExample = argResults![_optionNameRemoveExample] as bool;
@@ -78,7 +69,6 @@ If not specified the extracted API will be printed to the console.
     );
     final packageApi = await analyze(
       preparedPackageRef,
-      doMergeBaseClasses: !noMergeBaseClasses,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,
     );
@@ -95,6 +85,15 @@ If not specified the extracted API will be printed to the console.
       stdout.writeln('Public API of "$packageRef" written to $outFilePath');
     } else {
       stdout.writeln(jsonString);
+    }
+
+    final declarationsWithoutEntryPoints =
+        packageApi.getRootDeclarationsWithoutEntryPoints();
+    if (declarationsWithoutEntryPoints.isNotEmpty) {
+      stdout.writeln('The following declarations do not have an entry point:');
+      for (final declaration in declarationsWithoutEntryPoints) {
+        stdout.writeln('  ${declaration.name}');
+      }
     }
     return 0;
   }

--- a/lib/src/cli/commands/extract_command.dart
+++ b/lib/src/cli/commands/extract_command.dart
@@ -90,7 +90,8 @@ If not specified the extracted API will be printed to the console.
     final declarationsWithoutEntryPoints =
         packageApi.getRootDeclarationsWithoutEntryPoints();
     if (declarationsWithoutEntryPoints.isNotEmpty) {
-      stdout.writeln('The following declarations do not have an entry point:');
+      stdout.writeln(
+          'The following declarations do not have an entry point (did you miss to export them?):');
       for (final declaration in declarationsWithoutEntryPoints) {
         stdout.writeln('  ${declaration.name}');
       }

--- a/lib/src/cli/commands/extract_command.dart
+++ b/lib/src/cli/commands/extract_command.dart
@@ -12,6 +12,7 @@ String _optionNameOutput = 'output';
 String _optionNameNoAnalyzePlatformConstraints =
     'no-analyze-platform-constraints';
 String _optionNameRemoveExample = 'remove-example';
+String _optionNameSetExitCodeOnMissingExport = 'set-exit-on-missing-export';
 
 /// command to extract the public API of a package.
 /// This is used when, for example, the public API needs to be stored on disk
@@ -52,6 +53,13 @@ If not specified the extracted API will be printed to the console.
       defaultsTo: true,
       negatable: true,
     );
+    argParser.addFlag(
+      _optionNameSetExitCodeOnMissingExport,
+      help:
+          'Sets exit code to != 0 if missing exports are detected in the API.',
+      defaultsTo: false,
+      negatable: true,
+    );
   }
 
   @override
@@ -62,6 +70,8 @@ If not specified the extracted API will be printed to the console.
     final noAnalyzePlatformConstraints =
         argResults![_optionNameNoAnalyzePlatformConstraints] as bool;
     final doRemoveExample = argResults![_optionNameRemoveExample] as bool;
+    final doSetExitCodeOnMissingExport =
+        argResults![_optionNameSetExitCodeOnMissingExport] as bool;
 
     final preparedPackageRef = await prepare(
       packageRef,
@@ -94,6 +104,9 @@ If not specified the extracted API will be printed to the console.
           'The following declarations do not have an entry point (did you miss to export them?):');
       for (final declaration in declarationsWithoutEntryPoints) {
         stdout.writeln('  ${declaration.name}');
+      }
+      if (doSetExitCodeOnMissingExport) {
+        return -1;
       }
     }
     return 0;

--- a/lib/src/model/interface_declaration.dart
+++ b/lib/src/model/interface_declaration.dart
@@ -6,6 +6,7 @@ import '../utils/string_utils.dart';
 import 'declaration.dart';
 import 'executable_declaration.dart';
 import 'field_declaration.dart';
+import 'type_usage.dart';
 
 part 'interface_declaration.freezed.dart';
 
@@ -32,8 +33,11 @@ class InterfaceDeclaration with _$InterfaceDeclaration implements Declaration {
     /// determines if this declaration is sealed
     required bool isSealed,
 
-    /// whether this interface is "required" meaning: is meant to be implemented by the user of the containing package
-    required bool isRequired,
+    /// determines if this declaration is abstract
+    required bool isAbstract,
+
+    /// usages of this interface
+    required Set<TypeUsage> typeUsages,
 
     /// list of type parameter names
     required List<String> typeParameterNames,
@@ -62,4 +66,8 @@ class InterfaceDeclaration with _$InterfaceDeclaration implements Declaration {
     final typeParameterSuffix = getTypeParameterSuffix(typeParameterNames);
     return '$name$typeParameterSuffix$superTypeSuffix';
   }
+
+  /// determines if this interface is required (meaning: can be used in a type hierarchy by the consumer)
+  bool get isRequired =>
+      isAbstract && !isSealed && typeUsages.contains(TypeUsage.input);
 }

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -28,8 +28,11 @@ mixin _$InterfaceDeclaration {
   /// determines if this declaration is sealed
   bool get isSealed => throw _privateConstructorUsedError;
 
-  /// whether this interface is "required" meaning: is meant to be implemented by the user of the containing package
-  bool get isRequired => throw _privateConstructorUsedError;
+  /// determines if this declaration is abstract
+  bool get isAbstract => throw _privateConstructorUsedError;
+
+  /// usages of this interface
+  Set<TypeUsage> get typeUsages => throw _privateConstructorUsedError;
 
   /// list of type parameter names
   List<String> get typeParameterNames => throw _privateConstructorUsedError;
@@ -67,7 +70,8 @@ abstract class $InterfaceDeclarationCopyWith<$Res> {
       bool isDeprecated,
       bool isExperimental,
       bool isSealed,
-      bool isRequired,
+      bool isAbstract,
+      Set<TypeUsage> typeUsages,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclaration> executableDeclarations,
@@ -94,7 +98,8 @@ class _$InterfaceDeclarationCopyWithImpl<$Res,
     Object? isDeprecated = null,
     Object? isExperimental = null,
     Object? isSealed = null,
-    Object? isRequired = null,
+    Object? isAbstract = null,
+    Object? typeUsages = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -119,10 +124,14 @@ class _$InterfaceDeclarationCopyWithImpl<$Res,
           ? _value.isSealed
           : isSealed // ignore: cast_nullable_to_non_nullable
               as bool,
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
+      isAbstract: null == isAbstract
+          ? _value.isAbstract
+          : isAbstract // ignore: cast_nullable_to_non_nullable
               as bool,
+      typeUsages: null == typeUsages
+          ? _value.typeUsages
+          : typeUsages // ignore: cast_nullable_to_non_nullable
+              as Set<TypeUsage>,
       typeParameterNames: null == typeParameterNames
           ? _value.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
@@ -164,7 +173,8 @@ abstract class _$$_InterfaceDeclarationCopyWith<$Res>
       bool isDeprecated,
       bool isExperimental,
       bool isSealed,
-      bool isRequired,
+      bool isAbstract,
+      Set<TypeUsage> typeUsages,
       List<String> typeParameterNames,
       List<String> superTypeNames,
       List<ExecutableDeclaration> executableDeclarations,
@@ -188,7 +198,8 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
     Object? isDeprecated = null,
     Object? isExperimental = null,
     Object? isSealed = null,
-    Object? isRequired = null,
+    Object? isAbstract = null,
+    Object? typeUsages = null,
     Object? typeParameterNames = null,
     Object? superTypeNames = null,
     Object? executableDeclarations = null,
@@ -213,10 +224,14 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
           ? _value.isSealed
           : isSealed // ignore: cast_nullable_to_non_nullable
               as bool,
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
+      isAbstract: null == isAbstract
+          ? _value.isAbstract
+          : isAbstract // ignore: cast_nullable_to_non_nullable
               as bool,
+      typeUsages: null == typeUsages
+          ? _value._typeUsages
+          : typeUsages // ignore: cast_nullable_to_non_nullable
+              as Set<TypeUsage>,
       typeParameterNames: null == typeParameterNames
           ? _value._typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
@@ -253,14 +268,16 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
       required this.isDeprecated,
       required this.isExperimental,
       required this.isSealed,
-      required this.isRequired,
+      required this.isAbstract,
+      required final Set<TypeUsage> typeUsages,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclaration> executableDeclarations,
       required final List<FieldDeclaration> fieldDeclarations,
       final Set<String>? entryPoints,
       required this.relativePath})
-      : _typeParameterNames = typeParameterNames,
+      : _typeUsages = typeUsages,
+        _typeParameterNames = typeParameterNames,
         _superTypeNames = superTypeNames,
         _executableDeclarations = executableDeclarations,
         _fieldDeclarations = fieldDeclarations,
@@ -283,9 +300,20 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   @override
   final bool isSealed;
 
-  /// whether this interface is "required" meaning: is meant to be implemented by the user of the containing package
+  /// determines if this declaration is abstract
   @override
-  final bool isRequired;
+  final bool isAbstract;
+
+  /// usages of this interface
+  final Set<TypeUsage> _typeUsages;
+
+  /// usages of this interface
+  @override
+  Set<TypeUsage> get typeUsages {
+    if (_typeUsages is EqualUnmodifiableSetView) return _typeUsages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableSetView(_typeUsages);
+  }
 
   /// list of type parameter names
   final List<String> _typeParameterNames;
@@ -353,7 +381,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
 
   @override
   String toString() {
-    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
+    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isAbstract: $isAbstract, typeUsages: $typeUsages, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 
   @override
@@ -368,8 +396,10 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
                 other.isExperimental == isExperimental) &&
             (identical(other.isSealed, isSealed) ||
                 other.isSealed == isSealed) &&
-            (identical(other.isRequired, isRequired) ||
-                other.isRequired == isRequired) &&
+            (identical(other.isAbstract, isAbstract) ||
+                other.isAbstract == isAbstract) &&
+            const DeepCollectionEquality()
+                .equals(other._typeUsages, _typeUsages) &&
             const DeepCollectionEquality()
                 .equals(other._typeParameterNames, _typeParameterNames) &&
             const DeepCollectionEquality()
@@ -391,7 +421,8 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
       isDeprecated,
       isExperimental,
       isSealed,
-      isRequired,
+      isAbstract,
+      const DeepCollectionEquality().hash(_typeUsages),
       const DeepCollectionEquality().hash(_typeParameterNames),
       const DeepCollectionEquality().hash(_superTypeNames),
       const DeepCollectionEquality().hash(_executableDeclarations),
@@ -414,7 +445,8 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
       required final bool isDeprecated,
       required final bool isExperimental,
       required final bool isSealed,
-      required final bool isRequired,
+      required final bool isAbstract,
+      required final Set<TypeUsage> typeUsages,
       required final List<String> typeParameterNames,
       required final List<String> superTypeNames,
       required final List<ExecutableDeclaration> executableDeclarations,
@@ -441,8 +473,12 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
   bool get isSealed;
   @override
 
-  /// whether this interface is "required" meaning: is meant to be implemented by the user of the containing package
-  bool get isRequired;
+  /// determines if this declaration is abstract
+  bool get isAbstract;
+  @override
+
+  /// usages of this interface
+  Set<TypeUsage> get typeUsages;
   @override
 
   /// list of type parameter names

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import '../interface_declaration.dart';
 import '../executable_declaration.dart';
 import '../field_declaration.dart';
+import '../type_usage.dart';
 import 'internal_declaration.dart';
 import 'internal_declaration_utils.dart';
 
@@ -110,19 +111,21 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           superClassIds: [],
         );
 
-  InterfaceDeclaration toInterfaceDeclaration({required bool isRequired}) {
+  InterfaceDeclaration toInterfaceDeclaration(
+      {required Set<TypeUsage> typeUsages}) {
     final namespacePrefix = namespace == null ? '' : '$namespace.';
     return InterfaceDeclaration(
       name: '$namespacePrefix$name',
       isDeprecated: isDeprecated,
       isExperimental: isExperimental,
       isSealed: isSealed,
+      isAbstract: isAbstract,
       typeParameterNames: typeParameterNames,
       superTypeNames: superTypeNames,
       executableDeclarations: executableDeclarations,
       fieldDeclarations: fieldDeclarations,
       entryPoints: entryPoints,
-      isRequired: isRequired,
+      typeUsages: typeUsages,
       relativePath: relativePath,
     );
   }

--- a/lib/src/model/model.dart
+++ b/lib/src/model/model.dart
@@ -9,3 +9,4 @@ export 'platform_constraints.dart';
 export 'sdk_type.dart';
 export 'type_alias_declaration.dart';
 export 'type_hierarchy.dart';
+export 'type_usage.dart';

--- a/lib/src/model/package_api.dart
+++ b/lib/src/model/package_api.dart
@@ -1,15 +1,6 @@
-import 'package:dart_apitool/src/model/platform_constraints.dart';
-import 'package:dart_apitool/src/model/type_alias_declaration.dart';
+import 'package:dart_apitool/api_tool.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:pub_semver/pub_semver.dart';
-
-import 'interface_declaration.dart';
-import 'executable_declaration.dart';
-import 'field_declaration.dart';
-import 'package_api_semantics.dart';
-import 'package_dependency.dart';
-import 'sdk_type.dart';
-import 'type_hierarchy.dart';
 
 part 'package_api.freezed.dart';
 
@@ -61,4 +52,15 @@ class PackageApi with _$PackageApi {
     /// the type hierarchy of the public API
     required TypeHierarchy typeHierarchy,
   }) = _PackageApi;
+
+  /// returns all root level declarations of this package that don't have any entry points
+  Iterable<Declaration> getRootDeclarationsWithoutEntryPoints() {
+    return [
+      ...interfaceDeclarations.where((id) => id.entryPoints?.isEmpty ?? false),
+      ...executableDeclarations.where((ed) => ed.entryPoints?.isEmpty ?? false),
+      ...typeAliasDeclarations
+          .where((tad) => tad.entryPoints?.isEmpty ?? false),
+      ...fieldDeclarations.where((fd) => fd.entryPoints?.isEmpty ?? false),
+    ];
+  }
 }

--- a/lib/src/model/package_api_semantics.dart
+++ b/lib/src/model/package_api_semantics.dart
@@ -2,9 +2,6 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 /// defines the semantics used in a [PackageApi] model
 enum PackageApiSemantics {
-  /// base classes have been merged into the derived classes
-  @JsonValue("mergeBaseClasses")
-  mergeBaseClasses,
   @JsonValue("containsPlatformConstraints")
   containsPlatformConstraints,
 }

--- a/lib/src/model/type_usage.dart
+++ b/lib/src/model/type_usage.dart
@@ -1,0 +1,14 @@
+/// specifies how a type is used
+enum TypeUsage {
+  /// the type is provided in the public API
+  provide,
+
+  /// the type is used to be passed into the API
+  input,
+
+  /// the type is used to be returned from the API
+  output,
+
+  /// the type is used as a hierarchy element (base class, mixin, interface, type parameter ...)
+  hierarchy,
+}

--- a/lib/src/storage/v3/package_api_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.g.dart
@@ -72,7 +72,6 @@ Map<String, dynamic> _$$_PackageApiStorageV3ToJson(
     };
 
 const _$PackageApiSemanticsEnumMap = {
-  PackageApiSemantics.mergeBaseClasses: 'mergeBaseClasses',
   PackageApiSemantics.containsPlatformConstraints:
       'containsPlatformConstraints',
 };

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -104,5 +104,50 @@ void main() {
       ]);
       expect(exitCode, 0);
     });
+
+    test('Handles `set-exit-on-missing-export` well if nothing is missing',
+        () async {
+      final extractCommand = ExtractCommand();
+      final runner =
+          CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+            ..addCommand(extractCommand);
+      // executes "extract" command for a package that doesn't misses an export
+      // `--set-exit-on-missing-export` is set` and the exit code should be 0 (no missing export found)
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        path.join(
+          'test',
+          'test_packages',
+          'nested_path_references',
+          'package_a',
+        ),
+        '--include-path-dependencies',
+        '--set-exit-on-missing-export',
+      ]);
+      expect(exitCode, 0);
+    });
+
+    test('Handles `set-exit-on-missing-export` well if an export is missing',
+        () async {
+      final extractCommand = ExtractCommand();
+      final runner =
+          CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+            ..addCommand(extractCommand);
+      // executes "extract" command for a package that misses an export
+      // `--set-exit-on-missing-export` is set` and the exit code should be -1
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        path.join(
+          'test',
+          'test_packages',
+          'missing_export',
+          'package_a',
+        ),
+        '--set-exit-on-missing-export',
+      ]);
+      expect(exitCode, -1);
+    });
   }, timeout: Timeout(Duration(minutes: 2)));
 }

--- a/test/integration_tests/diff/test_package_experimental_test.dart
+++ b/test/integration_tests/diff/test_package_experimental_test.dart
@@ -35,31 +35,35 @@ void main() {
       });
 
       test('detects removal of experimental flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassA' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassA' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'name' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'name' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'getName' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'getName' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });
@@ -73,31 +77,35 @@ void main() {
       });
 
       test('detects addition of experimental flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassA' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassA' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'name' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'name' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'getName' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'getName' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });

--- a/test/integration_tests/diff/test_package_sealed_test.dart
+++ b/test/integration_tests/diff/test_package_sealed_test.dart
@@ -35,24 +35,26 @@ void main() {
       });
 
       test('detects removal of sealed flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + remove method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassD' &&
-                element.changeDescription.contains('Sealed') &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassD' &&
+                  change.changeDescription.contains('Sealed') &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'newMethod' &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'newMethod' &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });
@@ -66,24 +68,26 @@ void main() {
       });
 
       test('detects addition of sealed flag', () {
-        expect(diffResult.apiChanges.length,
-            6); // experimental + meta package + sealed + add method
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'ClassD' &&
-                element.changeDescription.contains('Sealed') &&
-                element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'ClassD' &&
+                  change.changeDescription.contains('Sealed') &&
+                  change.isBreaking,
+            ),
           ),
-          isTrue,
         );
         expect(
-          diffResult.apiChanges.any(
-            (element) =>
-                element.affectedDeclaration?.name == 'newMethod' &&
-                !element.isBreaking,
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.affectedDeclaration?.name == 'newMethod' &&
+                  !change.isBreaking,
+            ),
           ),
-          isTrue,
         );
       });
     });

--- a/test/package_api_differ_test_data.dart
+++ b/test/package_api_differ_test_data.dart
@@ -5,6 +5,7 @@ final simpleClassA = InterfaceDeclaration(
   isDeprecated: false,
   isExperimental: false,
   isSealed: false,
+  isAbstract: false,
   typeParameterNames: const [],
   superTypeNames: const [],
   executableDeclarations: const [
@@ -21,7 +22,7 @@ final simpleClassA = InterfaceDeclaration(
     ),
   ],
   fieldDeclarations: const [],
-  isRequired: false,
+  typeUsages: {},
   relativePath: '',
 );
 final simpleClassB = InterfaceDeclaration(
@@ -29,6 +30,7 @@ final simpleClassB = InterfaceDeclaration(
   isDeprecated: false,
   isExperimental: false,
   isSealed: false,
+  isAbstract: false,
   typeParameterNames: const [],
   superTypeNames: const [],
   executableDeclarations: const [
@@ -45,7 +47,7 @@ final simpleClassB = InterfaceDeclaration(
     ),
   ],
   fieldDeclarations: const [],
-  isRequired: false,
+  typeUsages: {},
   relativePath: '',
 );
 

--- a/test/package_api_storage_test.dart
+++ b/test/package_api_storage_test.dart
@@ -87,6 +87,7 @@ final testPackage1Api = PackageApi(
       isDeprecated: false,
       isExperimental: false,
       isSealed: false,
+      isAbstract: false,
       typeParameterNames: const ['T'],
       superTypeNames: const ['SuperType'],
       executableDeclarations: [
@@ -133,7 +134,7 @@ final testPackage1Api = PackageApi(
           relativePath: '',
         ),
       ],
-      isRequired: false,
+      typeUsages: {},
       relativePath: '',
     )
   ],
@@ -222,6 +223,7 @@ final testPackage2Api = PackageApi(
       isDeprecated: false,
       isExperimental: false,
       isSealed: false,
+      isAbstract: false,
       typeParameterNames: const ['T'],
       superTypeNames: const ['SuperType'],
       executableDeclarations: [
@@ -271,7 +273,7 @@ final testPackage2Api = PackageApi(
         ),
       ],
       entryPoints: {},
-      isRequired: false,
+      typeUsages: {},
       relativePath: '',
     ),
   ],

--- a/test/test_packages/missing_export/package_a/.gitignore
+++ b/test/test_packages/missing_export/package_a/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/missing_export/package_a/CHANGELOG.md
+++ b/test/test_packages/missing_export/package_a/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/missing_export/package_a/README.md
+++ b/test/test_packages/missing_export/package_a/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/missing_export/package_a/analysis_options.yaml
+++ b/test/test_packages/missing_export/package_a/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/missing_export/package_a/lib/package_a.dart
+++ b/test/test_packages/missing_export/package_a/lib/package_a.dart
@@ -1,0 +1,3 @@
+library package_a;
+
+export 'types/class_a.dart';

--- a/test/test_packages/missing_export/package_a/lib/types/class_a.dart
+++ b/test/test_packages/missing_export/package_a/lib/types/class_a.dart
@@ -1,0 +1,17 @@
+import 'package:meta/meta.dart';
+import 'package:package_b/package_b.dart';
+
+import 'class_b.dart';
+
+@experimental
+class ClassA {
+  final ClassB classB;
+
+  ClassA({required this.classB});
+
+  String getName() {
+    return classB.getName();
+  }
+
+  ClassB getClassB() => ClassB('someValue');
+}

--- a/test/test_packages/missing_export/package_a/lib/types/class_b.dart
+++ b/test/test_packages/missing_export/package_a/lib/types/class_b.dart
@@ -1,0 +1,5 @@
+class ClassB {
+  final String someProperty;
+
+  ClassB(this.someProperty);
+}

--- a/test/test_packages/missing_export/package_a/pubspec.yaml
+++ b/test/test_packages/missing_export/package_a/pubspec.yaml
@@ -1,0 +1,16 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+publish_to: none
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dependencies:
+  collection: ^1.17.0
+  meta: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
This PR adds a first check for interfaces that are part of the public API but are not exported.
This is done by gathering a bit more information about the usage context of a type (and along the way replacing `isRequired`) to then strip out all interfaces that are not used as input or output and are not reachable (have no entry points).
All interfaces that are left afterwards and have no entry points are potentially problematic as they are used as input or output but are not addressable from a consumer of the package.

Also introduces ` --[no-]set-exit-on-missing-export` flag for the extract command that fails the export if a missing export is detected.
This is the compromise on having this check available without introducing an `analyze` command with exactly one check.  
If we get more checks in the future we can think about moving this check to a new `analyze` command.

resolves #134 

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
