### PR TITLE
respect dev dependencies when looking for path dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.14.1
+- Fixes an issue with path dev-dependencies
+
 ## Version 0.14.0
 - improves change type detection for parameter type changes (widening types is now considered non-breaking)
 - ignores enum constructors and elements marked with @override

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -162,8 +162,10 @@ Affects only local references.
 
     final yamlContent = await pubspecFile.readAsString();
     final pubSpec = Pubspec.parse(yamlContent);
-    await Future.forEach<Dependency>(pubSpec.dependencies.values,
-        (dependency) async {
+    await Future.forEach<Dependency>([
+      ...pubSpec.dependencies.values,
+      ...pubSpec.devDependencies.values,
+    ], (dependency) async {
       if (dependency is PathDependency) {
         String pathDependencyPath =
             p.normalize(p.join(packagePath, dependency.path));

--- a/test/test_packages/path_references/cluster_a/package_b/pubspec.yaml
+++ b/test/test_packages/path_references/cluster_a/package_b/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   collection: ^1.17.0
   meta: ^1.8.0
-  package_c:
-    path: ../../cluster_b/package_c
 
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0
+  package_c:
+    path: ../../cluster_b/package_c


### PR DESCRIPTION
## Description
This PR fixes the functionality to collect path dependencies to also look at dev dependencies.

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
