### PR TITLE
remove effect of `--dependency-check-mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.14.2
+- Remove effect of `--dependency-check-mode` and add a deprecation warning (for why refer to https://github.com/bmw-tech/dart_apitool/issues/144)
+
 ## Version 0.14.1
 - Fixes an issue with path dev-dependencies
 - Fixes issues with isSealed handling (extracted JSON was wrong) thanks @hamsbrar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.14.2
+## Version 0.15.0
 - Remove effect of `--dependency-check-mode` and add a deprecation warning (for why refer to https://github.com/bmw-tech/dart_apitool/issues/144)
 
 ## Version 0.14.1

--- a/README.md
+++ b/README.md
@@ -91,13 +91,10 @@ Usage: dart-apitool diff [arguments]
                                          (defaults to on)
     --[no-]ignore-prerelease             Determines if the pre-release aspect of the new version
                                          shall be ignored when checking versions.
-                                         This only makes sense in combination with --dependency-check-mode != none.
                                          You may want to do this if you want to make sure
                                          (in your CI) that the version - once ready - matches semver.
                                          (defaults to on)
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
-    --dependency-check-mode              Defines the mode package dependency changes are handled.
-                                         [none, allowAdding, strict (default)]
     --[no-]remove-example                Removes examples from the package to analyze.
                                          (defaults to on)
     --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces (yielding less strict version bump requirements)

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -64,7 +64,6 @@ This affects the exit code of this program.
       help: '''
 Determines if the pre-release aspect of the new version
 shall be ignored when checking versions.
-This only makes sense in combination with --$_optionNameDependencyCheckMode != ${VersionCheckMode.none.name}.
 You may want to do this if you want to make sure
 (in your CI) that the version - once ready - matches semver.
 ''',
@@ -79,9 +78,11 @@ You may want to do this if you want to make sure
     );
     argParser.addOption(
       _optionNameDependencyCheckMode,
-      help: 'Defines the mode package dependency changes are handled.',
+      help: 'DEPRECATED - this option as no effect any more',
+      // ignore: deprecated_member_use_from_same_package
       allowed: DependencyCheckMode.values.map((e) => e.name).toList(),
-      defaultsTo: DependencyCheckMode.strict.name,
+      // ignore: deprecated_member_use_from_same_package
+      defaultsTo: DependencyCheckMode.allowAdding.name,
     );
     argParser.addFlag(
       _optionNameRemoveExample,
@@ -110,9 +111,12 @@ You may want to do this if you want to make sure
     final doCheckSdkVersion = argResults![_optionNameCheckSdkVersion] as bool;
     final noAnalyzePlatformConstraints =
         argResults![_optionNameNoAnalyzePlatformConstraints] as bool;
-    final dependencyCheckMode = DependencyCheckMode.values.firstWhere(
-        (element) =>
-            element.name == argResults![_optionNameDependencyCheckMode]);
+    if (argResults?.arguments
+            .any((a) => a == '--$_optionNameDependencyCheckMode') ??
+        false) {
+      stdout.writeln(
+          'You are using the option "$_optionNameDependencyCheckMode" that has no effect any more and will be removed in a future release (and will lead to an exception if specified)');
+    }
     final doRemoveExample = argResults![_optionNameRemoveExample] as bool;
     final doIgnoreRequiredness =
         argResults![_optionNameIgnoreRequiredness] as bool;
@@ -143,7 +147,6 @@ You may want to do this if you want to make sure
     final differ = PackageApiDiffer(
       options: PackageApiDifferOptions(
         doCheckSdkVersion: doCheckSdkVersion,
-        dependencyCheckMode: dependencyCheckMode,
         doIgnoreRequiredness: doIgnoreRequiredness,
       ),
     );

--- a/lib/src/diff/dependency_check_mode.dart
+++ b/lib/src/diff/dependency_check_mode.dart
@@ -1,3 +1,5 @@
+@Deprecated(
+    'This enum as no effect any more and will be removed in a future release')
 enum DependencyCheckMode {
   none,
   allowAdding,

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -11,7 +11,6 @@ import '../errors/errors.dart';
 import 'api_change.dart';
 import 'api_change_code.dart';
 import 'api_change_type.dart';
-import 'dependency_check_mode.dart';
 import 'package_api_diff_result.dart';
 import 'package_api_differ_options.dart';
 

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -1075,9 +1075,6 @@ class PackageApiDiffer {
       PackageApi oldApi, PackageApi newApi,
       {required bool isExperimental}) {
     final result = <ApiChange>[];
-    if (options.dependencyCheckMode == DependencyCheckMode.none) {
-      return result;
-    }
     final oldDependencies = oldApi.packageDependencies;
     final newDependencies = newApi.packageDependencies;
     final oldDependenciesMap =
@@ -1098,9 +1095,7 @@ class PackageApiDiffer {
             changeCode: ApiChangeCode.cd01,
             affectedDeclaration: null,
             contextTrace: [],
-            type: options.dependencyCheckMode == DependencyCheckMode.allowAdding
-                ? ApiChangeType.addCompatibleMinor
-                : ApiChangeType.addBreaking,
+            type: ApiChangeType.addCompatibleMinor,
             isExperimental: isExperimental,
             changeDescription: 'Package dependency added: "$dependencyName"',
           ),
@@ -1145,7 +1140,7 @@ class PackageApiDiffer {
             affectedDeclaration: null,
             contextTrace: [],
             type: !isNonBreakingVersionChange
-                ? ApiChangeType.changeBreaking
+                ? ApiChangeType.changeCompatibleMinor
                 : ApiChangeType.changeCompatiblePatch,
             isExperimental: isExperimental,
             changeDescription:

--- a/lib/src/diff/package_api_differ_options.dart
+++ b/lib/src/diff/package_api_differ_options.dart
@@ -1,5 +1,3 @@
-import 'dependency_check_mode.dart';
-
 /// represents options for the [PackageApiDiffer]
 class PackageApiDifferOptions {
   /// whether to ignore type parameter changes
@@ -8,9 +6,6 @@ class PackageApiDifferOptions {
   /// whether to ignore sdk version changes
   final bool doCheckSdkVersion;
 
-  /// how to check for dependency changes
-  final DependencyCheckMode dependencyCheckMode;
-
   /// whether the requiredness aspect of interfaces shall be ignored (to be less strict about version bump requirements)
   final bool doIgnoreRequiredness;
 
@@ -18,7 +13,6 @@ class PackageApiDifferOptions {
   const PackageApiDifferOptions({
     this.ignoreTypeParameterNameChanges = true,
     this.doCheckSdkVersion = true,
-    this.dependencyCheckMode = DependencyCheckMode.strict,
     this.doIgnoreRequiredness = false,
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.14.2-dev
+version: 0.15.0-dev
 
 environment:
   sdk: ">=2.17.5 <3.0.0"

--- a/test/integration_tests/diff/flutter_blue_test.dart
+++ b/test/integration_tests/diff/flutter_blue_test.dart
@@ -29,7 +29,7 @@ void main() {
             diffResult.apiChanges.any((element) =>
                 element.changeDescription.contains('dependency') &&
                 element.changeDescription.contains('rxdart') &&
-                element.type == ApiChangeType.addBreaking),
+                element.type == ApiChangeType.addCompatibleMinor),
             isTrue);
         expect(
             diffResult.apiChanges.any((element) =>
@@ -37,33 +37,7 @@ void main() {
                 element.changeDescription.contains('protobuf') &&
                 element.changeDescription.contains('^0.10.5') &&
                 element.changeDescription.contains('^0.13.12') &&
-                element.type == ApiChangeType.changeBreaking),
-            isTrue);
-      });
-
-      test('Differ option "allowAdd" works', () async {
-        final allowAddDiffResult = PackageApiDiffer(
-            options: PackageApiDifferOptions(
-          dependencyCheckMode: DependencyCheckMode.allowAdding,
-        )).diff(
-            oldApi: await retriever_0_5_0.retrieve(),
-            newApi: await retriever_0_6_0.retrieve());
-
-        // adding dependencies is no not breaking
-        expect(
-            allowAddDiffResult.apiChanges.any((element) =>
-                element.changeDescription.contains('dependency') &&
-                element.changeDescription.contains('rxdart') &&
-                element.type == ApiChangeType.addCompatibleMinor),
-            isTrue);
-        // changes are still breaking
-        expect(
-            allowAddDiffResult.apiChanges.any((element) =>
-                element.changeDescription.contains('dependency') &&
-                element.changeDescription.contains('protobuf') &&
-                element.changeDescription.contains('^0.10.5') &&
-                element.changeDescription.contains('^0.13.12') &&
-                element.type == ApiChangeType.changeBreaking),
+                element.type == ApiChangeType.changeCompatibleMinor),
             isTrue);
       });
     });

--- a/test/integration_tests/diff/xterm_test.dart
+++ b/test/integration_tests/diff/xterm_test.dart
@@ -77,7 +77,7 @@ void main() {
                 element.changeDescription.contains('quiver') &&
                 element.changeDescription.contains('^2.1.3') &&
                 element.changeDescription.contains('^3.0.0') &&
-                element.type == ApiChangeType.changeBreaking),
+                element.type == ApiChangeType.changeCompatibleMinor),
             isTrue);
       });
     });


### PR DESCRIPTION
## Description
This PR removes the effect of `--dependency-check-mode` as this is no longer needed (see #144)
Solves issue #144 

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
