### PR TITLE
fix: removes pubspec_overrides.yaml from a package downloaded from pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.16.1
+- fixes issues with pubspec_overrides.yaml that got published with a pub package
+
 ## Version 0.16.0
 - simplify preparation of packages by replacing the directory structure copy operation with carrying over the package config (that contains the absolute paths to the original path references). Thanks to @mosuem and @jonasfj for this idea! This makes the `--include-path-dependencies` option obsolete. This option has no effect anymore and will be removed in a future version.
 

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -79,6 +79,16 @@ OBSOLETE: Has no effect anymore.
             File(_getPackageConfigPathForPackage(tempDir.path))
               ..createSync(recursive: true);
         await sourcePackageConfig.copy(targetPackageConfig.path);
+      } else {
+        await stdoutSession.writeln('Cleaning up local copy of pub package');
+        // Check if we have a pub packages that bundles a pubspec_overrides.yaml (as this most probably destroys pub get)
+        final pubspecOverrides = File(p.join(
+            sourceItem.destinationPath(forPrefix: tempDir.path),
+            'pubspec_overrides.yaml'));
+        if (await pubspecOverrides.exists()) {
+          await pubspecOverrides.delete();
+          await stdoutSession.writeln('- Removed pubspec_overrides.yaml');
+        }
       }
     });
     return PreparedPackageRef(

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -81,7 +81,7 @@ OBSOLETE: Has no effect anymore.
         await sourcePackageConfig.copy(targetPackageConfig.path);
       } else {
         await stdoutSession.writeln('Cleaning up local copy of pub package');
-        // Check if we have a pub packages that bundles a pubspec_overrides.yaml (as this most probably destroys pub get)
+        // Check if we have a pub package that bundles a pubspec_overrides.yaml (as this most probably destroys pub get)
         final pubspecOverrides = File(p.join(
             sourceItem.destinationPath(forPrefix: tempDir.path),
             'pubspec_overrides.yaml'));


### PR DESCRIPTION
## Description
If a package bundles a pubspec_overrides.yaml (e.g. because it lives in a multi-package repo) that overrides are most probably no longer valid for the package in isolation.
This is no problem if a package gets referenced as the overrides only work locally.

In dart_apitool's case this is a problem as it wants to run pub get on a local copy of that package and therefore needs to clean up pubspec_overrides if they exist.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
