### PR TITLE
fix: make relative paths in copied package_config.json absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.16.2
+- fixes relative path handling in package config (leading to unresolvable types)
+
 ## Version 0.16.1
 - fixes issues with pubspec_overrides.yaml that got published with a pub package
 


### PR DESCRIPTION
## Description
The current approach of copying the package_config.json works but has issues with relative paths.
If a package has relative path dependencies then they will end up as relative paths in the package_config.json.
After copying the package_config.json to its new place (a temporary directory) those paths are no longer valid.

This PR adds functionality that adapts all relative paths in the package_config.json to absolute ones so that the analyzer can still resolve types from those packages.

Symptom: Unresolved types in the public API

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
