### PR TITLE
fix: fixes local package refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.16.3
 - adds more diff result reporting options (cli, json, markdown)
+- fixes broken local packages refs
 
 ## Version 0.16.2
 - fixes relative path handling in package config (leading to unresolvable types)

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -533,7 +533,7 @@ class _InterfaceCollectionResult {
 }
 
 @freezed
-class _FileToAnalyzeEntry with _$_FileToAnalyzeEntry {
+class _FileToAnalyzeEntry with _$FileToAnalyzeEntry {
   const factory _FileToAnalyzeEntry({
     required String filePath,
     @Default([]) List<String> shownNames,

--- a/lib/src/analyze/package_api_analyzer.freezed.dart
+++ b/lib/src/analyze/package_api_analyzer.freezed.dart
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 /// @nodoc
-mixin _$_FileToAnalyzeEntry {
+mixin _$FileToAnalyzeEntry {
   String get filePath => throw _privateConstructorUsedError;
   List<String> get shownNames => throw _privateConstructorUsedError;
   List<String> get hiddenNames => throw _privateConstructorUsedError;
@@ -79,11 +79,11 @@ class __$FileToAnalyzeEntryCopyWithImpl<$Res, $Val extends _FileToAnalyzeEntry>
 }
 
 /// @nodoc
-abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
+abstract class _$$_FileToAnalyzeEntryImplCopyWith<$Res>
     implements _$FileToAnalyzeEntryCopyWith<$Res> {
-  factory _$$__FileToAnalyzeEntryCopyWith(_$__FileToAnalyzeEntry value,
-          $Res Function(_$__FileToAnalyzeEntry) then) =
-      __$$__FileToAnalyzeEntryCopyWithImpl<$Res>;
+  factory _$$_FileToAnalyzeEntryImplCopyWith(_$_FileToAnalyzeEntryImpl value,
+          $Res Function(_$_FileToAnalyzeEntryImpl) then) =
+      __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -94,11 +94,11 @@ abstract class _$$__FileToAnalyzeEntryCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$__FileToAnalyzeEntryCopyWithImpl<$Res>
-    extends __$FileToAnalyzeEntryCopyWithImpl<$Res, _$__FileToAnalyzeEntry>
-    implements _$$__FileToAnalyzeEntryCopyWith<$Res> {
-  __$$__FileToAnalyzeEntryCopyWithImpl(_$__FileToAnalyzeEntry _value,
-      $Res Function(_$__FileToAnalyzeEntry) _then)
+class __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>
+    extends __$FileToAnalyzeEntryCopyWithImpl<$Res, _$_FileToAnalyzeEntryImpl>
+    implements _$$_FileToAnalyzeEntryImplCopyWith<$Res> {
+  __$$_FileToAnalyzeEntryImplCopyWithImpl(_$_FileToAnalyzeEntryImpl _value,
+      $Res Function(_$_FileToAnalyzeEntryImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -109,7 +109,7 @@ class __$$__FileToAnalyzeEntryCopyWithImpl<$Res>
     Object? hiddenNames = null,
     Object? exportedBy = null,
   }) {
-    return _then(_$__FileToAnalyzeEntry(
+    return _then(_$_FileToAnalyzeEntryImpl(
       filePath: null == filePath
           ? _value.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
@@ -132,8 +132,8 @@ class __$$__FileToAnalyzeEntryCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
-  const _$__FileToAnalyzeEntry(
+class _$_FileToAnalyzeEntryImpl implements __FileToAnalyzeEntry {
+  const _$_FileToAnalyzeEntryImpl(
       {required this.filePath,
       final List<String> shownNames = const [],
       final List<String> hiddenNames = const [],
@@ -179,7 +179,7 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$__FileToAnalyzeEntry &&
+            other is _$_FileToAnalyzeEntryImpl &&
             (identical(other.filePath, filePath) ||
                 other.filePath == filePath) &&
             const DeepCollectionEquality()
@@ -201,8 +201,8 @@ class _$__FileToAnalyzeEntry implements __FileToAnalyzeEntry {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$__FileToAnalyzeEntryCopyWith<_$__FileToAnalyzeEntry> get copyWith =>
-      __$$__FileToAnalyzeEntryCopyWithImpl<_$__FileToAnalyzeEntry>(
+  _$$_FileToAnalyzeEntryImplCopyWith<_$_FileToAnalyzeEntryImpl> get copyWith =>
+      __$$_FileToAnalyzeEntryImplCopyWithImpl<_$_FileToAnalyzeEntryImpl>(
           this, _$identity);
 }
 
@@ -211,7 +211,7 @@ abstract class __FileToAnalyzeEntry implements _FileToAnalyzeEntry {
       {required final String filePath,
       final List<String> shownNames,
       final List<String> hiddenNames,
-      required final Set<String> exportedBy}) = _$__FileToAnalyzeEntry;
+      required final Set<String> exportedBy}) = _$_FileToAnalyzeEntryImpl;
 
   @override
   String get filePath;
@@ -223,6 +223,6 @@ abstract class __FileToAnalyzeEntry implements _FileToAnalyzeEntry {
   Set<String> get exportedBy;
   @override
   @JsonKey(ignore: true)
-  _$$__FileToAnalyzeEntryCopyWith<_$__FileToAnalyzeEntry> get copyWith =>
+  _$$_FileToAnalyzeEntryImplCopyWith<_$_FileToAnalyzeEntryImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -201,6 +201,8 @@ OBSOLETE: Has no effect anymore.
     required String sourcePackageConfigPath,
   }) async {
     final sourcePackageConfigDirPath = p.dirname(sourcePackageConfigPath);
+    final sourcePackageDirPath =
+        Directory(sourcePackageConfigDirPath).parent.path;
     final targetPackageConfigContent =
         jsonDecode(await File(targetPackageConfigPath).readAsString());
     // iterate through the package_config.json content and look for relative paths
@@ -211,6 +213,10 @@ OBSOLETE: Has no effect anymore.
         // we make the relative path absolute by using the origin of the source package config as a base
         final normalizedPackagePath =
             p.normalize(p.join(sourcePackageConfigDirPath, packagePath));
+        // if the relative path is the package path, then don't make it absolute
+        if (p.equals(sourcePackageDirPath, normalizedPackagePath)) {
+          continue;
+        }
         // and write the new absolute path back to the json structure
         packageConfig['rootUri'] = p.toUri(normalizedPackagePath).toString();
       }

--- a/lib/src/model/executable_declaration.freezed.dart
+++ b/lib/src/model/executable_declaration.freezed.dart
@@ -125,12 +125,12 @@ class _$ExecutableParameterDeclarationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
+abstract class _$$ExecutableParameterDeclarationImplCopyWith<$Res>
     implements $ExecutableParameterDeclarationCopyWith<$Res> {
-  factory _$$_ExecutableParameterDeclarationCopyWith(
-          _$_ExecutableParameterDeclaration value,
-          $Res Function(_$_ExecutableParameterDeclaration) then) =
-      __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>;
+  factory _$$ExecutableParameterDeclarationImplCopyWith(
+          _$ExecutableParameterDeclarationImpl value,
+          $Res Function(_$ExecutableParameterDeclarationImpl) then) =
+      __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -145,13 +145,13 @@ abstract class _$$_ExecutableParameterDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>
+class __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>
     extends _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-        _$_ExecutableParameterDeclaration>
-    implements _$$_ExecutableParameterDeclarationCopyWith<$Res> {
-  __$$_ExecutableParameterDeclarationCopyWithImpl(
-      _$_ExecutableParameterDeclaration _value,
-      $Res Function(_$_ExecutableParameterDeclaration) _then)
+        _$ExecutableParameterDeclarationImpl>
+    implements _$$ExecutableParameterDeclarationImplCopyWith<$Res> {
+  __$$ExecutableParameterDeclarationImplCopyWithImpl(
+      _$ExecutableParameterDeclarationImpl _value,
+      $Res Function(_$ExecutableParameterDeclarationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -166,7 +166,7 @@ class __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>
     Object? typeFullLibraryName = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$_ExecutableParameterDeclaration(
+    return _then(_$ExecutableParameterDeclarationImpl(
       isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
@@ -205,9 +205,9 @@ class __$$_ExecutableParameterDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ExecutableParameterDeclaration
+class _$ExecutableParameterDeclarationImpl
     extends _ExecutableParameterDeclaration {
-  const _$_ExecutableParameterDeclaration(
+  const _$ExecutableParameterDeclarationImpl(
       {required this.isRequired,
       required this.isNamed,
       required this.name,
@@ -259,7 +259,7 @@ class _$_ExecutableParameterDeclaration
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ExecutableParameterDeclaration &&
+            other is _$ExecutableParameterDeclarationImpl &&
             (identical(other.isRequired, isRequired) ||
                 other.isRequired == isRequired) &&
             (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
@@ -291,22 +291,24 @@ class _$_ExecutableParameterDeclaration
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ExecutableParameterDeclarationCopyWith<_$_ExecutableParameterDeclaration>
-      get copyWith => __$$_ExecutableParameterDeclarationCopyWithImpl<
-          _$_ExecutableParameterDeclaration>(this, _$identity);
+  _$$ExecutableParameterDeclarationImplCopyWith<
+          _$ExecutableParameterDeclarationImpl>
+      get copyWith => __$$ExecutableParameterDeclarationImplCopyWithImpl<
+          _$ExecutableParameterDeclarationImpl>(this, _$identity);
 }
 
 abstract class _ExecutableParameterDeclaration
     extends ExecutableParameterDeclaration implements Declaration {
   const factory _ExecutableParameterDeclaration(
-      {required final bool isRequired,
-      required final bool isNamed,
-      required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final String typeName,
-      required final String? typeFullLibraryName,
-      required final String relativePath}) = _$_ExecutableParameterDeclaration;
+          {required final bool isRequired,
+          required final bool isNamed,
+          required final String name,
+          required final bool isDeprecated,
+          required final bool isExperimental,
+          required final String typeName,
+          required final String? typeFullLibraryName,
+          required final String relativePath}) =
+      _$ExecutableParameterDeclarationImpl;
   const _ExecutableParameterDeclaration._() : super._();
 
   @override
@@ -343,7 +345,8 @@ abstract class _ExecutableParameterDeclaration
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_ExecutableParameterDeclarationCopyWith<_$_ExecutableParameterDeclaration>
+  _$$ExecutableParameterDeclarationImplCopyWith<
+          _$ExecutableParameterDeclarationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -475,11 +478,12 @@ class _$ExecutableDeclarationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ExecutableDeclarationCopyWith<$Res>
+abstract class _$$ExecutableDeclarationImplCopyWith<$Res>
     implements $ExecutableDeclarationCopyWith<$Res> {
-  factory _$$_ExecutableDeclarationCopyWith(_$_ExecutableDeclaration value,
-          $Res Function(_$_ExecutableDeclaration) then) =
-      __$$_ExecutableDeclarationCopyWithImpl<$Res>;
+  factory _$$ExecutableDeclarationImplCopyWith(
+          _$ExecutableDeclarationImpl value,
+          $Res Function(_$ExecutableDeclarationImpl) then) =
+      __$$ExecutableDeclarationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -496,11 +500,12 @@ abstract class _$$_ExecutableDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ExecutableDeclarationCopyWithImpl<$Res>
-    extends _$ExecutableDeclarationCopyWithImpl<$Res, _$_ExecutableDeclaration>
-    implements _$$_ExecutableDeclarationCopyWith<$Res> {
-  __$$_ExecutableDeclarationCopyWithImpl(_$_ExecutableDeclaration _value,
-      $Res Function(_$_ExecutableDeclaration) _then)
+class __$$ExecutableDeclarationImplCopyWithImpl<$Res>
+    extends _$ExecutableDeclarationCopyWithImpl<$Res,
+        _$ExecutableDeclarationImpl>
+    implements _$$ExecutableDeclarationImplCopyWith<$Res> {
+  __$$ExecutableDeclarationImplCopyWithImpl(_$ExecutableDeclarationImpl _value,
+      $Res Function(_$ExecutableDeclarationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -517,7 +522,7 @@ class __$$_ExecutableDeclarationCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$_ExecutableDeclaration(
+    return _then(_$ExecutableDeclarationImpl(
       returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
@@ -564,8 +569,8 @@ class __$$_ExecutableDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_ExecutableDeclaration extends _ExecutableDeclaration {
-  const _$_ExecutableDeclaration(
+class _$ExecutableDeclarationImpl extends _ExecutableDeclaration {
+  const _$ExecutableDeclarationImpl(
       {required this.returnTypeName,
       required this.name,
       required this.isDeprecated,
@@ -654,7 +659,7 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ExecutableDeclaration &&
+            other is _$ExecutableDeclarationImpl &&
             (identical(other.returnTypeName, returnTypeName) ||
                 other.returnTypeName == returnTypeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -692,9 +697,9 @@ class _$_ExecutableDeclaration extends _ExecutableDeclaration {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ExecutableDeclarationCopyWith<_$_ExecutableDeclaration> get copyWith =>
-      __$$_ExecutableDeclarationCopyWithImpl<_$_ExecutableDeclaration>(
-          this, _$identity);
+  _$$ExecutableDeclarationImplCopyWith<_$ExecutableDeclarationImpl>
+      get copyWith => __$$ExecutableDeclarationImplCopyWithImpl<
+          _$ExecutableDeclarationImpl>(this, _$identity);
 }
 
 abstract class _ExecutableDeclaration extends ExecutableDeclaration {
@@ -708,7 +713,7 @@ abstract class _ExecutableDeclaration extends ExecutableDeclaration {
       required final ExecutableType type,
       required final bool isStatic,
       final Set<String>? entryPoints,
-      required final String relativePath}) = _$_ExecutableDeclaration;
+      required final String relativePath}) = _$ExecutableDeclarationImpl;
   const _ExecutableDeclaration._() : super._();
 
   @override
@@ -753,6 +758,6 @@ abstract class _ExecutableDeclaration extends ExecutableDeclaration {
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_ExecutableDeclarationCopyWith<_$_ExecutableDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$ExecutableDeclarationImplCopyWith<_$ExecutableDeclarationImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/model/field_declaration.freezed.dart
+++ b/lib/src/model/field_declaration.freezed.dart
@@ -113,11 +113,11 @@ class _$FieldDeclarationCopyWithImpl<$Res, $Val extends FieldDeclaration>
 }
 
 /// @nodoc
-abstract class _$$_FieldDeclarationCopyWith<$Res>
+abstract class _$$FieldDeclarationImplCopyWith<$Res>
     implements $FieldDeclarationCopyWith<$Res> {
-  factory _$$_FieldDeclarationCopyWith(
-          _$_FieldDeclaration value, $Res Function(_$_FieldDeclaration) then) =
-      __$$_FieldDeclarationCopyWithImpl<$Res>;
+  factory _$$FieldDeclarationImplCopyWith(_$FieldDeclarationImpl value,
+          $Res Function(_$FieldDeclarationImpl) then) =
+      __$$FieldDeclarationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -131,11 +131,11 @@ abstract class _$$_FieldDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FieldDeclarationCopyWithImpl<$Res>
-    extends _$FieldDeclarationCopyWithImpl<$Res, _$_FieldDeclaration>
-    implements _$$_FieldDeclarationCopyWith<$Res> {
-  __$$_FieldDeclarationCopyWithImpl(
-      _$_FieldDeclaration _value, $Res Function(_$_FieldDeclaration) _then)
+class __$$FieldDeclarationImplCopyWithImpl<$Res>
+    extends _$FieldDeclarationCopyWithImpl<$Res, _$FieldDeclarationImpl>
+    implements _$$FieldDeclarationImplCopyWith<$Res> {
+  __$$FieldDeclarationImplCopyWithImpl(_$FieldDeclarationImpl _value,
+      $Res Function(_$FieldDeclarationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -149,7 +149,7 @@ class __$$_FieldDeclarationCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$_FieldDeclaration(
+    return _then(_$FieldDeclarationImpl(
       typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
@@ -184,8 +184,8 @@ class __$$_FieldDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_FieldDeclaration extends _FieldDeclaration {
-  const _$_FieldDeclaration(
+class _$FieldDeclarationImpl extends _FieldDeclaration {
+  const _$FieldDeclarationImpl(
       {required this.typeName,
       required this.name,
       required this.isDeprecated,
@@ -242,7 +242,7 @@ class _$_FieldDeclaration extends _FieldDeclaration {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FieldDeclaration &&
+            other is _$FieldDeclarationImpl &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -272,8 +272,9 @@ class _$_FieldDeclaration extends _FieldDeclaration {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FieldDeclarationCopyWith<_$_FieldDeclaration> get copyWith =>
-      __$$_FieldDeclarationCopyWithImpl<_$_FieldDeclaration>(this, _$identity);
+  _$$FieldDeclarationImplCopyWith<_$FieldDeclarationImpl> get copyWith =>
+      __$$FieldDeclarationImplCopyWithImpl<_$FieldDeclarationImpl>(
+          this, _$identity);
 }
 
 abstract class _FieldDeclaration extends FieldDeclaration
@@ -285,7 +286,7 @@ abstract class _FieldDeclaration extends FieldDeclaration
       required final bool isStatic,
       required final bool isExperimental,
       final Set<String>? entryPoints,
-      required final String relativePath}) = _$_FieldDeclaration;
+      required final String relativePath}) = _$FieldDeclarationImpl;
   const _FieldDeclaration._() : super._();
 
   @override
@@ -318,6 +319,6 @@ abstract class _FieldDeclaration extends FieldDeclaration
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_FieldDeclarationCopyWith<_$_FieldDeclaration> get copyWith =>
+  _$$FieldDeclarationImplCopyWith<_$FieldDeclarationImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -161,11 +161,11 @@ class _$InterfaceDeclarationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_InterfaceDeclarationCopyWith<$Res>
+abstract class _$$InterfaceDeclarationImplCopyWith<$Res>
     implements $InterfaceDeclarationCopyWith<$Res> {
-  factory _$$_InterfaceDeclarationCopyWith(_$_InterfaceDeclaration value,
-          $Res Function(_$_InterfaceDeclaration) then) =
-      __$$_InterfaceDeclarationCopyWithImpl<$Res>;
+  factory _$$InterfaceDeclarationImplCopyWith(_$InterfaceDeclarationImpl value,
+          $Res Function(_$InterfaceDeclarationImpl) then) =
+      __$$InterfaceDeclarationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -184,11 +184,11 @@ abstract class _$$_InterfaceDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_InterfaceDeclarationCopyWithImpl<$Res>
-    extends _$InterfaceDeclarationCopyWithImpl<$Res, _$_InterfaceDeclaration>
-    implements _$$_InterfaceDeclarationCopyWith<$Res> {
-  __$$_InterfaceDeclarationCopyWithImpl(_$_InterfaceDeclaration _value,
-      $Res Function(_$_InterfaceDeclaration) _then)
+class __$$InterfaceDeclarationImplCopyWithImpl<$Res>
+    extends _$InterfaceDeclarationCopyWithImpl<$Res, _$InterfaceDeclarationImpl>
+    implements _$$InterfaceDeclarationImplCopyWith<$Res> {
+  __$$InterfaceDeclarationImplCopyWithImpl(_$InterfaceDeclarationImpl _value,
+      $Res Function(_$InterfaceDeclarationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -207,7 +207,7 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$_InterfaceDeclaration(
+    return _then(_$InterfaceDeclarationImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -262,8 +262,8 @@ class __$$_InterfaceDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_InterfaceDeclaration extends _InterfaceDeclaration {
-  const _$_InterfaceDeclaration(
+class _$InterfaceDeclarationImpl extends _InterfaceDeclaration {
+  const _$InterfaceDeclarationImpl(
       {required this.name,
       required this.isDeprecated,
       required this.isExperimental,
@@ -388,7 +388,7 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_InterfaceDeclaration &&
+            other is _$InterfaceDeclarationImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
@@ -433,9 +433,10 @@ class _$_InterfaceDeclaration extends _InterfaceDeclaration {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_InterfaceDeclarationCopyWith<_$_InterfaceDeclaration> get copyWith =>
-      __$$_InterfaceDeclarationCopyWithImpl<_$_InterfaceDeclaration>(
-          this, _$identity);
+  _$$InterfaceDeclarationImplCopyWith<_$InterfaceDeclarationImpl>
+      get copyWith =>
+          __$$InterfaceDeclarationImplCopyWithImpl<_$InterfaceDeclarationImpl>(
+              this, _$identity);
 }
 
 abstract class _InterfaceDeclaration extends InterfaceDeclaration
@@ -452,7 +453,7 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
       required final List<ExecutableDeclaration> executableDeclarations,
       required final List<FieldDeclaration> fieldDeclarations,
       final Set<String>? entryPoints,
-      required final String relativePath}) = _$_InterfaceDeclaration;
+      required final String relativePath}) = _$InterfaceDeclarationImpl;
   const _InterfaceDeclaration._() : super._();
 
   @override
@@ -505,6 +506,6 @@ abstract class _InterfaceDeclaration extends InterfaceDeclaration
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_InterfaceDeclarationCopyWith<_$_InterfaceDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$InterfaceDeclarationImplCopyWith<_$InterfaceDeclarationImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/model/package_api.freezed.dart
+++ b/lib/src/model/package_api.freezed.dart
@@ -212,11 +212,11 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
 }
 
 /// @nodoc
-abstract class _$$_PackageApiCopyWith<$Res>
+abstract class _$$PackageApiImplCopyWith<$Res>
     implements $PackageApiCopyWith<$Res> {
-  factory _$$_PackageApiCopyWith(
-          _$_PackageApi value, $Res Function(_$_PackageApi) then) =
-      __$$_PackageApiCopyWithImpl<$Res>;
+  factory _$$PackageApiImplCopyWith(
+          _$PackageApiImpl value, $Res Function(_$PackageApiImpl) then) =
+      __$$PackageApiImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -242,11 +242,11 @@ abstract class _$$_PackageApiCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PackageApiCopyWithImpl<$Res>
-    extends _$PackageApiCopyWithImpl<$Res, _$_PackageApi>
-    implements _$$_PackageApiCopyWith<$Res> {
-  __$$_PackageApiCopyWithImpl(
-      _$_PackageApi _value, $Res Function(_$_PackageApi) _then)
+class __$$PackageApiImplCopyWithImpl<$Res>
+    extends _$PackageApiCopyWithImpl<$Res, _$PackageApiImpl>
+    implements _$$PackageApiImplCopyWith<$Res> {
+  __$$PackageApiImplCopyWithImpl(
+      _$PackageApiImpl _value, $Res Function(_$PackageApiImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -267,7 +267,7 @@ class __$$_PackageApiCopyWithImpl<$Res>
     Object? minSdkVersion = null,
     Object? typeHierarchy = null,
   }) {
-    return _then(_$_PackageApi(
+    return _then(_$PackageApiImpl(
       packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
@@ -330,8 +330,8 @@ class __$$_PackageApiCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_PackageApi extends _PackageApi {
-  const _$_PackageApi(
+class _$PackageApiImpl extends _PackageApi {
+  const _$PackageApiImpl(
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
@@ -467,7 +467,7 @@ class _$_PackageApi extends _PackageApi {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PackageApi &&
+            other is _$PackageApiImpl &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -520,8 +520,8 @@ class _$_PackageApi extends _PackageApi {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PackageApiCopyWith<_$_PackageApi> get copyWith =>
-      __$$_PackageApiCopyWithImpl<_$_PackageApi>(this, _$identity);
+  _$$PackageApiImplCopyWith<_$PackageApiImpl> get copyWith =>
+      __$$PackageApiImplCopyWithImpl<_$PackageApiImpl>(this, _$identity);
 }
 
 abstract class _PackageApi extends PackageApi {
@@ -539,7 +539,7 @@ abstract class _PackageApi extends PackageApi {
       required final SdkType sdkType,
       required final List<PackageDependency> packageDependencies,
       required final Version minSdkVersion,
-      required final TypeHierarchy typeHierarchy}) = _$_PackageApi;
+      required final TypeHierarchy typeHierarchy}) = _$PackageApiImpl;
   const _PackageApi._() : super._();
 
   @override
@@ -600,6 +600,6 @@ abstract class _PackageApi extends PackageApi {
   TypeHierarchy get typeHierarchy;
   @override
   @JsonKey(ignore: true)
-  _$$_PackageApiCopyWith<_$_PackageApi> get copyWith =>
+  _$$PackageApiImplCopyWith<_$PackageApiImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/model/package_dependency.freezed.dart
+++ b/lib/src/model/package_dependency.freezed.dart
@@ -66,22 +66,22 @@ class _$PackageDependencyCopyWithImpl<$Res, $Val extends PackageDependency>
 }
 
 /// @nodoc
-abstract class _$$_PackageDependencyCopyWith<$Res>
+abstract class _$$PackageDependencyImplCopyWith<$Res>
     implements $PackageDependencyCopyWith<$Res> {
-  factory _$$_PackageDependencyCopyWith(_$_PackageDependency value,
-          $Res Function(_$_PackageDependency) then) =
-      __$$_PackageDependencyCopyWithImpl<$Res>;
+  factory _$$PackageDependencyImplCopyWith(_$PackageDependencyImpl value,
+          $Res Function(_$PackageDependencyImpl) then) =
+      __$$PackageDependencyImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String packageName, String? packageVersion});
 }
 
 /// @nodoc
-class __$$_PackageDependencyCopyWithImpl<$Res>
-    extends _$PackageDependencyCopyWithImpl<$Res, _$_PackageDependency>
-    implements _$$_PackageDependencyCopyWith<$Res> {
-  __$$_PackageDependencyCopyWithImpl(
-      _$_PackageDependency _value, $Res Function(_$_PackageDependency) _then)
+class __$$PackageDependencyImplCopyWithImpl<$Res>
+    extends _$PackageDependencyCopyWithImpl<$Res, _$PackageDependencyImpl>
+    implements _$$PackageDependencyImplCopyWith<$Res> {
+  __$$PackageDependencyImplCopyWithImpl(_$PackageDependencyImpl _value,
+      $Res Function(_$PackageDependencyImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -90,7 +90,7 @@ class __$$_PackageDependencyCopyWithImpl<$Res>
     Object? packageName = null,
     Object? packageVersion = freezed,
   }) {
-    return _then(_$_PackageDependency(
+    return _then(_$PackageDependencyImpl(
       packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
@@ -105,8 +105,8 @@ class __$$_PackageDependencyCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_PackageDependency implements _PackageDependency {
-  _$_PackageDependency(
+class _$PackageDependencyImpl implements _PackageDependency {
+  _$PackageDependencyImpl(
       {required this.packageName, required this.packageVersion});
 
   /// name of the package
@@ -126,7 +126,7 @@ class _$_PackageDependency implements _PackageDependency {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PackageDependency &&
+            other is _$PackageDependencyImpl &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -139,15 +139,15 @@ class _$_PackageDependency implements _PackageDependency {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PackageDependencyCopyWith<_$_PackageDependency> get copyWith =>
-      __$$_PackageDependencyCopyWithImpl<_$_PackageDependency>(
+  _$$PackageDependencyImplCopyWith<_$PackageDependencyImpl> get copyWith =>
+      __$$PackageDependencyImplCopyWithImpl<_$PackageDependencyImpl>(
           this, _$identity);
 }
 
 abstract class _PackageDependency implements PackageDependency {
   factory _PackageDependency(
       {required final String packageName,
-      required final String? packageVersion}) = _$_PackageDependency;
+      required final String? packageVersion}) = _$PackageDependencyImpl;
 
   @override
 
@@ -159,6 +159,6 @@ abstract class _PackageDependency implements PackageDependency {
   String? get packageVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_PackageDependencyCopyWith<_$_PackageDependency> get copyWith =>
+  _$$PackageDependencyImplCopyWith<_$PackageDependencyImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/model/platform_constraints.freezed.dart
+++ b/lib/src/model/platform_constraints.freezed.dart
@@ -59,23 +59,25 @@ class _$IOSPlatformConstraintsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_IOSPlatformConstraintsCopyWith<$Res>
+abstract class _$$IOSPlatformConstraintsImplCopyWith<$Res>
     implements $IOSPlatformConstraintsCopyWith<$Res> {
-  factory _$$_IOSPlatformConstraintsCopyWith(_$_IOSPlatformConstraints value,
-          $Res Function(_$_IOSPlatformConstraints) then) =
-      __$$_IOSPlatformConstraintsCopyWithImpl<$Res>;
+  factory _$$IOSPlatformConstraintsImplCopyWith(
+          _$IOSPlatformConstraintsImpl value,
+          $Res Function(_$IOSPlatformConstraintsImpl) then) =
+      __$$IOSPlatformConstraintsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class __$$_IOSPlatformConstraintsCopyWithImpl<$Res>
+class __$$IOSPlatformConstraintsImplCopyWithImpl<$Res>
     extends _$IOSPlatformConstraintsCopyWithImpl<$Res,
-        _$_IOSPlatformConstraints>
-    implements _$$_IOSPlatformConstraintsCopyWith<$Res> {
-  __$$_IOSPlatformConstraintsCopyWithImpl(_$_IOSPlatformConstraints _value,
-      $Res Function(_$_IOSPlatformConstraints) _then)
+        _$IOSPlatformConstraintsImpl>
+    implements _$$IOSPlatformConstraintsImplCopyWith<$Res> {
+  __$$IOSPlatformConstraintsImplCopyWithImpl(
+      _$IOSPlatformConstraintsImpl _value,
+      $Res Function(_$IOSPlatformConstraintsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -83,7 +85,7 @@ class __$$_IOSPlatformConstraintsCopyWithImpl<$Res>
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
-    return _then(_$_IOSPlatformConstraints(
+    return _then(_$IOSPlatformConstraintsImpl(
       minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
@@ -94,8 +96,8 @@ class __$$_IOSPlatformConstraintsCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_IOSPlatformConstraints implements _IOSPlatformConstraints {
-  const _$_IOSPlatformConstraints({required this.minimumOsVersion});
+class _$IOSPlatformConstraintsImpl implements _IOSPlatformConstraints {
+  const _$IOSPlatformConstraintsImpl({required this.minimumOsVersion});
 
   /// minimum iOS version
   @override
@@ -110,7 +112,7 @@ class _$_IOSPlatformConstraints implements _IOSPlatformConstraints {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_IOSPlatformConstraints &&
+            other is _$IOSPlatformConstraintsImpl &&
             (identical(other.minimumOsVersion, minimumOsVersion) ||
                 other.minimumOsVersion == minimumOsVersion));
   }
@@ -121,14 +123,14 @@ class _$_IOSPlatformConstraints implements _IOSPlatformConstraints {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_IOSPlatformConstraintsCopyWith<_$_IOSPlatformConstraints> get copyWith =>
-      __$$_IOSPlatformConstraintsCopyWithImpl<_$_IOSPlatformConstraints>(
-          this, _$identity);
+  _$$IOSPlatformConstraintsImplCopyWith<_$IOSPlatformConstraintsImpl>
+      get copyWith => __$$IOSPlatformConstraintsImplCopyWithImpl<
+          _$IOSPlatformConstraintsImpl>(this, _$identity);
 }
 
 abstract class _IOSPlatformConstraints implements IOSPlatformConstraints {
   const factory _IOSPlatformConstraints(
-      {required final num? minimumOsVersion}) = _$_IOSPlatformConstraints;
+      {required final num? minimumOsVersion}) = _$IOSPlatformConstraintsImpl;
 
   @override
 
@@ -136,8 +138,8 @@ abstract class _IOSPlatformConstraints implements IOSPlatformConstraints {
   num? get minimumOsVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_IOSPlatformConstraintsCopyWith<_$_IOSPlatformConstraints> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$IOSPlatformConstraintsImplCopyWith<_$IOSPlatformConstraintsImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -203,12 +205,12 @@ class _$AndroidPlatformConstraintsCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AndroidPlatformConstraintsCopyWith<$Res>
+abstract class _$$AndroidPlatformConstraintsImplCopyWith<$Res>
     implements $AndroidPlatformConstraintsCopyWith<$Res> {
-  factory _$$_AndroidPlatformConstraintsCopyWith(
-          _$_AndroidPlatformConstraints value,
-          $Res Function(_$_AndroidPlatformConstraints) then) =
-      __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>;
+  factory _$$AndroidPlatformConstraintsImplCopyWith(
+          _$AndroidPlatformConstraintsImpl value,
+          $Res Function(_$AndroidPlatformConstraintsImpl) then) =
+      __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -216,13 +218,13 @@ abstract class _$$_AndroidPlatformConstraintsCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
+class __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>
     extends _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-        _$_AndroidPlatformConstraints>
-    implements _$$_AndroidPlatformConstraintsCopyWith<$Res> {
-  __$$_AndroidPlatformConstraintsCopyWithImpl(
-      _$_AndroidPlatformConstraints _value,
-      $Res Function(_$_AndroidPlatformConstraints) _then)
+        _$AndroidPlatformConstraintsImpl>
+    implements _$$AndroidPlatformConstraintsImplCopyWith<$Res> {
+  __$$AndroidPlatformConstraintsImplCopyWithImpl(
+      _$AndroidPlatformConstraintsImpl _value,
+      $Res Function(_$AndroidPlatformConstraintsImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -232,7 +234,7 @@ class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
     Object? compileSdkVersion = freezed,
     Object? targetSdkVersion = freezed,
   }) {
-    return _then(_$_AndroidPlatformConstraints(
+    return _then(_$AndroidPlatformConstraintsImpl(
       minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
@@ -251,8 +253,8 @@ class __$$_AndroidPlatformConstraintsCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_AndroidPlatformConstraints implements _AndroidPlatformConstraints {
-  const _$_AndroidPlatformConstraints(
+class _$AndroidPlatformConstraintsImpl implements _AndroidPlatformConstraints {
+  const _$AndroidPlatformConstraintsImpl(
       {required this.minSdkVersion,
       required this.compileSdkVersion,
       required this.targetSdkVersion});
@@ -278,7 +280,7 @@ class _$_AndroidPlatformConstraints implements _AndroidPlatformConstraints {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AndroidPlatformConstraints &&
+            other is _$AndroidPlatformConstraintsImpl &&
             (identical(other.minSdkVersion, minSdkVersion) ||
                 other.minSdkVersion == minSdkVersion) &&
             (identical(other.compileSdkVersion, compileSdkVersion) ||
@@ -294,9 +296,9 @@ class _$_AndroidPlatformConstraints implements _AndroidPlatformConstraints {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AndroidPlatformConstraintsCopyWith<_$_AndroidPlatformConstraints>
-      get copyWith => __$$_AndroidPlatformConstraintsCopyWithImpl<
-          _$_AndroidPlatformConstraints>(this, _$identity);
+  _$$AndroidPlatformConstraintsImplCopyWith<_$AndroidPlatformConstraintsImpl>
+      get copyWith => __$$AndroidPlatformConstraintsImplCopyWithImpl<
+          _$AndroidPlatformConstraintsImpl>(this, _$identity);
 }
 
 abstract class _AndroidPlatformConstraints
@@ -304,7 +306,7 @@ abstract class _AndroidPlatformConstraints
   const factory _AndroidPlatformConstraints(
       {required final int? minSdkVersion,
       required final int? compileSdkVersion,
-      required final int? targetSdkVersion}) = _$_AndroidPlatformConstraints;
+      required final int? targetSdkVersion}) = _$AndroidPlatformConstraintsImpl;
 
   @override
 
@@ -320,6 +322,6 @@ abstract class _AndroidPlatformConstraints
   int? get targetSdkVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_AndroidPlatformConstraintsCopyWith<_$_AndroidPlatformConstraints>
+  _$$AndroidPlatformConstraintsImplCopyWith<_$AndroidPlatformConstraintsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/model/type_alias_declaration.freezed.dart
+++ b/lib/src/model/type_alias_declaration.freezed.dart
@@ -105,11 +105,11 @@ class _$TypeAliasDeclarationCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
+abstract class _$$TypeAliasDeclarationImplCopyWith<$Res>
     implements $TypeAliasDeclarationCopyWith<$Res> {
-  factory _$$_TypeAliasDeclarationCopyWith(_$_TypeAliasDeclaration value,
-          $Res Function(_$_TypeAliasDeclaration) then) =
-      __$$_TypeAliasDeclarationCopyWithImpl<$Res>;
+  factory _$$TypeAliasDeclarationImplCopyWith(_$TypeAliasDeclarationImpl value,
+          $Res Function(_$TypeAliasDeclarationImpl) then) =
+      __$$TypeAliasDeclarationImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -122,11 +122,11 @@ abstract class _$$_TypeAliasDeclarationCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_TypeAliasDeclarationCopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationCopyWithImpl<$Res, _$_TypeAliasDeclaration>
-    implements _$$_TypeAliasDeclarationCopyWith<$Res> {
-  __$$_TypeAliasDeclarationCopyWithImpl(_$_TypeAliasDeclaration _value,
-      $Res Function(_$_TypeAliasDeclaration) _then)
+class __$$TypeAliasDeclarationImplCopyWithImpl<$Res>
+    extends _$TypeAliasDeclarationCopyWithImpl<$Res, _$TypeAliasDeclarationImpl>
+    implements _$$TypeAliasDeclarationImplCopyWith<$Res> {
+  __$$TypeAliasDeclarationImplCopyWithImpl(_$TypeAliasDeclarationImpl _value,
+      $Res Function(_$TypeAliasDeclarationImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -139,7 +139,7 @@ class __$$_TypeAliasDeclarationCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$_TypeAliasDeclaration(
+    return _then(_$TypeAliasDeclarationImpl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -170,8 +170,8 @@ class __$$_TypeAliasDeclarationCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TypeAliasDeclaration extends _TypeAliasDeclaration {
-  const _$_TypeAliasDeclaration(
+class _$TypeAliasDeclarationImpl extends _TypeAliasDeclaration {
+  const _$TypeAliasDeclarationImpl(
       {required this.name,
       required this.aliasedTypeName,
       required this.isDeprecated,
@@ -223,7 +223,7 @@ class _$_TypeAliasDeclaration extends _TypeAliasDeclaration {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TypeAliasDeclaration &&
+            other is _$TypeAliasDeclarationImpl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.aliasedTypeName, aliasedTypeName) ||
                 other.aliasedTypeName == aliasedTypeName) &&
@@ -250,9 +250,10 @@ class _$_TypeAliasDeclaration extends _TypeAliasDeclaration {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TypeAliasDeclarationCopyWith<_$_TypeAliasDeclaration> get copyWith =>
-      __$$_TypeAliasDeclarationCopyWithImpl<_$_TypeAliasDeclaration>(
-          this, _$identity);
+  _$$TypeAliasDeclarationImplCopyWith<_$TypeAliasDeclarationImpl>
+      get copyWith =>
+          __$$TypeAliasDeclarationImplCopyWithImpl<_$TypeAliasDeclarationImpl>(
+              this, _$identity);
 }
 
 abstract class _TypeAliasDeclaration extends TypeAliasDeclaration
@@ -263,7 +264,7 @@ abstract class _TypeAliasDeclaration extends TypeAliasDeclaration
       required final bool isDeprecated,
       required final bool isExperimental,
       final Set<String>? entryPoints,
-      required final String relativePath}) = _$_TypeAliasDeclaration;
+      required final String relativePath}) = _$TypeAliasDeclarationImpl;
   const _TypeAliasDeclaration._() : super._();
 
   @override
@@ -292,6 +293,6 @@ abstract class _TypeAliasDeclaration extends TypeAliasDeclaration
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_TypeAliasDeclarationCopyWith<_$_TypeAliasDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
+  _$$TypeAliasDeclarationImplCopyWith<_$TypeAliasDeclarationImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -245,7 +245,7 @@ class TypeHierarchy {
 
 /// represents a type in the type hierarchy
 @freezed
-class _TypeHierarchyItem with _$_TypeHierarchyItem {
+class _TypeHierarchyItem with _$TypeHierarchyItem {
   const _TypeHierarchyItem._();
 
   const factory _TypeHierarchyItem({

--- a/lib/src/model/type_hierarchy.freezed.dart
+++ b/lib/src/model/type_hierarchy.freezed.dart
@@ -75,11 +75,11 @@ class _$TypeIdentifierCopyWithImpl<$Res, $Val extends TypeIdentifier>
 }
 
 /// @nodoc
-abstract class _$$_TypeIdentifierCopyWith<$Res>
+abstract class _$$TypeIdentifierImplCopyWith<$Res>
     implements $TypeIdentifierCopyWith<$Res> {
-  factory _$$_TypeIdentifierCopyWith(
-          _$_TypeIdentifier value, $Res Function(_$_TypeIdentifier) then) =
-      __$$_TypeIdentifierCopyWithImpl<$Res>;
+  factory _$$TypeIdentifierImplCopyWith(_$TypeIdentifierImpl value,
+          $Res Function(_$TypeIdentifierImpl) then) =
+      __$$TypeIdentifierImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -87,11 +87,11 @@ abstract class _$$_TypeIdentifierCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_TypeIdentifierCopyWithImpl<$Res>
-    extends _$TypeIdentifierCopyWithImpl<$Res, _$_TypeIdentifier>
-    implements _$$_TypeIdentifierCopyWith<$Res> {
-  __$$_TypeIdentifierCopyWithImpl(
-      _$_TypeIdentifier _value, $Res Function(_$_TypeIdentifier) _then)
+class __$$TypeIdentifierImplCopyWithImpl<$Res>
+    extends _$TypeIdentifierCopyWithImpl<$Res, _$TypeIdentifierImpl>
+    implements _$$TypeIdentifierImplCopyWith<$Res> {
+  __$$TypeIdentifierImplCopyWithImpl(
+      _$TypeIdentifierImpl _value, $Res Function(_$TypeIdentifierImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -101,7 +101,7 @@ class __$$_TypeIdentifierCopyWithImpl<$Res>
     Object? packageName = null,
     Object? packageRelativeLibraryPath = null,
   }) {
-    return _then(_$_TypeIdentifier(
+    return _then(_$TypeIdentifierImpl(
       typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
@@ -120,8 +120,8 @@ class __$$_TypeIdentifierCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_TypeIdentifier extends _TypeIdentifier {
-  const _$_TypeIdentifier(
+class _$TypeIdentifierImpl extends _TypeIdentifier {
+  const _$TypeIdentifierImpl(
       {required this.typeName,
       required this.packageName,
       required this.packageRelativeLibraryPath})
@@ -143,7 +143,7 @@ class _$_TypeIdentifier extends _TypeIdentifier {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TypeIdentifier &&
+            other is _$TypeIdentifierImpl &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.packageName, packageName) ||
@@ -161,15 +161,16 @@ class _$_TypeIdentifier extends _TypeIdentifier {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TypeIdentifierCopyWith<_$_TypeIdentifier> get copyWith =>
-      __$$_TypeIdentifierCopyWithImpl<_$_TypeIdentifier>(this, _$identity);
+  _$$TypeIdentifierImplCopyWith<_$TypeIdentifierImpl> get copyWith =>
+      __$$TypeIdentifierImplCopyWithImpl<_$TypeIdentifierImpl>(
+          this, _$identity);
 }
 
 abstract class _TypeIdentifier extends TypeIdentifier {
   const factory _TypeIdentifier(
       {required final String typeName,
       required final String packageName,
-      required final String packageRelativeLibraryPath}) = _$_TypeIdentifier;
+      required final String packageRelativeLibraryPath}) = _$TypeIdentifierImpl;
   const _TypeIdentifier._() : super._();
 
   @override
@@ -186,12 +187,12 @@ abstract class _TypeIdentifier extends TypeIdentifier {
   String get packageRelativeLibraryPath;
   @override
   @JsonKey(ignore: true)
-  _$$_TypeIdentifierCopyWith<_$_TypeIdentifier> get copyWith =>
+  _$$TypeIdentifierImplCopyWith<_$TypeIdentifierImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 
 /// @nodoc
-mixin _$_TypeHierarchyItem {
+mixin _$TypeHierarchyItem {
   /// the identifier of this type
   TypeIdentifier get typeIdentifier => throw _privateConstructorUsedError;
 
@@ -254,11 +255,11 @@ class __$TypeHierarchyItemCopyWithImpl<$Res, $Val extends _TypeHierarchyItem>
 }
 
 /// @nodoc
-abstract class _$$__TypeHierarchyItemCopyWith<$Res>
+abstract class _$$_TypeHierarchyItemImplCopyWith<$Res>
     implements _$TypeHierarchyItemCopyWith<$Res> {
-  factory _$$__TypeHierarchyItemCopyWith(_$__TypeHierarchyItem value,
-          $Res Function(_$__TypeHierarchyItem) then) =
-      __$$__TypeHierarchyItemCopyWithImpl<$Res>;
+  factory _$$_TypeHierarchyItemImplCopyWith(_$_TypeHierarchyItemImpl value,
+          $Res Function(_$_TypeHierarchyItemImpl) then) =
+      __$$_TypeHierarchyItemImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -269,11 +270,11 @@ abstract class _$$__TypeHierarchyItemCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$__TypeHierarchyItemCopyWithImpl<$Res>
-    extends __$TypeHierarchyItemCopyWithImpl<$Res, _$__TypeHierarchyItem>
-    implements _$$__TypeHierarchyItemCopyWith<$Res> {
-  __$$__TypeHierarchyItemCopyWithImpl(
-      _$__TypeHierarchyItem _value, $Res Function(_$__TypeHierarchyItem) _then)
+class __$$_TypeHierarchyItemImplCopyWithImpl<$Res>
+    extends __$TypeHierarchyItemCopyWithImpl<$Res, _$_TypeHierarchyItemImpl>
+    implements _$$_TypeHierarchyItemImplCopyWith<$Res> {
+  __$$_TypeHierarchyItemImplCopyWithImpl(_$_TypeHierarchyItemImpl _value,
+      $Res Function(_$_TypeHierarchyItemImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -282,7 +283,7 @@ class __$$__TypeHierarchyItemCopyWithImpl<$Res>
     Object? typeIdentifier = null,
     Object? baseTypeIdentifiers = null,
   }) {
-    return _then(_$__TypeHierarchyItem(
+    return _then(_$_TypeHierarchyItemImpl(
       typeIdentifier: null == typeIdentifier
           ? _value.typeIdentifier
           : typeIdentifier // ignore: cast_nullable_to_non_nullable
@@ -297,8 +298,8 @@ class __$$__TypeHierarchyItemCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$__TypeHierarchyItem extends __TypeHierarchyItem {
-  const _$__TypeHierarchyItem(
+class _$_TypeHierarchyItemImpl extends __TypeHierarchyItem {
+  const _$_TypeHierarchyItemImpl(
       {required this.typeIdentifier,
       required final Set<TypeIdentifier> baseTypeIdentifiers})
       : _baseTypeIdentifiers = baseTypeIdentifiers,
@@ -324,7 +325,7 @@ class _$__TypeHierarchyItem extends __TypeHierarchyItem {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$__TypeHierarchyItem &&
+            other is _$_TypeHierarchyItemImpl &&
             (identical(other.typeIdentifier, typeIdentifier) ||
                 other.typeIdentifier == typeIdentifier) &&
             const DeepCollectionEquality()
@@ -338,8 +339,8 @@ class _$__TypeHierarchyItem extends __TypeHierarchyItem {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$__TypeHierarchyItemCopyWith<_$__TypeHierarchyItem> get copyWith =>
-      __$$__TypeHierarchyItemCopyWithImpl<_$__TypeHierarchyItem>(
+  _$$_TypeHierarchyItemImplCopyWith<_$_TypeHierarchyItemImpl> get copyWith =>
+      __$$_TypeHierarchyItemImplCopyWithImpl<_$_TypeHierarchyItemImpl>(
           this, _$identity);
 }
 
@@ -347,7 +348,7 @@ abstract class __TypeHierarchyItem extends _TypeHierarchyItem {
   const factory __TypeHierarchyItem(
           {required final TypeIdentifier typeIdentifier,
           required final Set<TypeIdentifier> baseTypeIdentifiers}) =
-      _$__TypeHierarchyItem;
+      _$_TypeHierarchyItemImpl;
   const __TypeHierarchyItem._() : super._();
 
   @override
@@ -360,6 +361,6 @@ abstract class __TypeHierarchyItem extends _TypeHierarchyItem {
   Set<TypeIdentifier> get baseTypeIdentifiers;
   @override
   @JsonKey(ignore: true)
-  _$$__TypeHierarchyItemCopyWith<_$__TypeHierarchyItem> get copyWith =>
+  _$$_TypeHierarchyItemImplCopyWith<_$_TypeHierarchyItemImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
@@ -112,12 +112,12 @@ class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
+abstract class _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<$Res>
     implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_ExecutableParameterDeclarationStorageV3CopyWith(
-          _$_ExecutableParameterDeclarationStorageV3 value,
-          $Res Function(_$_ExecutableParameterDeclarationStorageV3) then) =
-      __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>;
+  factory _$$ExecutableParameterDeclarationStorageV3ImplCopyWith(
+          _$ExecutableParameterDeclarationStorageV3Impl value,
+          $Res Function(_$ExecutableParameterDeclarationStorageV3Impl) then) =
+      __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -131,13 +131,13 @@ abstract class _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
+class __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<$Res>
     extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-        _$_ExecutableParameterDeclarationStorageV3>
-    implements _$$_ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
-  __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl(
-      _$_ExecutableParameterDeclarationStorageV3 _value,
-      $Res Function(_$_ExecutableParameterDeclarationStorageV3) _then)
+        _$ExecutableParameterDeclarationStorageV3Impl>
+    implements _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<$Res> {
+  __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl(
+      _$ExecutableParameterDeclarationStorageV3Impl _value,
+      $Res Function(_$ExecutableParameterDeclarationStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -151,7 +151,7 @@ class __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
     Object? typeName = null,
     Object? relativePath = null,
   }) {
-    return _then(_$_ExecutableParameterDeclarationStorageV3(
+    return _then(_$ExecutableParameterDeclarationStorageV3Impl(
       isRequired: null == isRequired
           ? _value.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
@@ -186,9 +186,9 @@ class __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_ExecutableParameterDeclarationStorageV3
+class _$ExecutableParameterDeclarationStorageV3Impl
     extends _ExecutableParameterDeclarationStorageV3 {
-  const _$_ExecutableParameterDeclarationStorageV3(
+  const _$ExecutableParameterDeclarationStorageV3Impl(
       {required this.isRequired,
       required this.isNamed,
       required this.name,
@@ -198,9 +198,9 @@ class _$_ExecutableParameterDeclarationStorageV3
       required this.relativePath})
       : super._();
 
-  factory _$_ExecutableParameterDeclarationStorageV3.fromJson(
+  factory _$ExecutableParameterDeclarationStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ExecutableParameterDeclarationStorageV3FromJson(json);
+      _$$ExecutableParameterDeclarationStorageV3ImplFromJson(json);
 
   @override
   final bool isRequired;
@@ -226,7 +226,7 @@ class _$_ExecutableParameterDeclarationStorageV3
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ExecutableParameterDeclarationStorageV3 &&
+            other is _$ExecutableParameterDeclarationStorageV3Impl &&
             (identical(other.isRequired, isRequired) ||
                 other.isRequired == isRequired) &&
             (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
@@ -249,14 +249,15 @@ class _$_ExecutableParameterDeclarationStorageV3
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ExecutableParameterDeclarationStorageV3CopyWith<
-          _$_ExecutableParameterDeclarationStorageV3>
-      get copyWith => __$$_ExecutableParameterDeclarationStorageV3CopyWithImpl<
-          _$_ExecutableParameterDeclarationStorageV3>(this, _$identity);
+  _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<
+          _$ExecutableParameterDeclarationStorageV3Impl>
+      get copyWith =>
+          __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<
+              _$ExecutableParameterDeclarationStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ExecutableParameterDeclarationStorageV3ToJson(
+    return _$$ExecutableParameterDeclarationStorageV3ImplToJson(
       this,
     );
   }
@@ -272,12 +273,12 @@ abstract class _ExecutableParameterDeclarationStorageV3
           required final bool isExperimental,
           required final String typeName,
           required final String relativePath}) =
-      _$_ExecutableParameterDeclarationStorageV3;
+      _$ExecutableParameterDeclarationStorageV3Impl;
   const _ExecutableParameterDeclarationStorageV3._() : super._();
 
   factory _ExecutableParameterDeclarationStorageV3.fromJson(
           Map<String, dynamic> json) =
-      _$_ExecutableParameterDeclarationStorageV3.fromJson;
+      _$ExecutableParameterDeclarationStorageV3Impl.fromJson;
 
   @override
   bool get isRequired;
@@ -295,8 +296,8 @@ abstract class _ExecutableParameterDeclarationStorageV3
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_ExecutableParameterDeclarationStorageV3CopyWith<
-          _$_ExecutableParameterDeclarationStorageV3>
+  _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<
+          _$ExecutableParameterDeclarationStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -417,12 +418,12 @@ class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
+abstract class _$$ExecutableDeclarationStorageV3ImplCopyWith<$Res>
     implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_ExecutableDeclarationStorageV3CopyWith(
-          _$_ExecutableDeclarationStorageV3 value,
-          $Res Function(_$_ExecutableDeclarationStorageV3) then) =
-      __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>;
+  factory _$$ExecutableDeclarationStorageV3ImplCopyWith(
+          _$ExecutableDeclarationStorageV3Impl value,
+          $Res Function(_$ExecutableDeclarationStorageV3Impl) then) =
+      __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -439,13 +440,13 @@ abstract class _$$_ExecutableDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>
+class __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<$Res>
     extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-        _$_ExecutableDeclarationStorageV3>
-    implements _$$_ExecutableDeclarationStorageV3CopyWith<$Res> {
-  __$$_ExecutableDeclarationStorageV3CopyWithImpl(
-      _$_ExecutableDeclarationStorageV3 _value,
-      $Res Function(_$_ExecutableDeclarationStorageV3) _then)
+        _$ExecutableDeclarationStorageV3Impl>
+    implements _$$ExecutableDeclarationStorageV3ImplCopyWith<$Res> {
+  __$$ExecutableDeclarationStorageV3ImplCopyWithImpl(
+      _$ExecutableDeclarationStorageV3Impl _value,
+      $Res Function(_$ExecutableDeclarationStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -462,7 +463,7 @@ class __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$_ExecutableDeclarationStorageV3(
+    return _then(_$ExecutableDeclarationStorageV3Impl(
       returnTypeName: null == returnTypeName
           ? _value.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
@@ -509,9 +510,9 @@ class __$$_ExecutableDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_ExecutableDeclarationStorageV3
+class _$ExecutableDeclarationStorageV3Impl
     extends _ExecutableDeclarationStorageV3 {
-  const _$_ExecutableDeclarationStorageV3(
+  const _$ExecutableDeclarationStorageV3Impl(
       {required this.returnTypeName,
       required this.name,
       required this.isDeprecated,
@@ -527,9 +528,9 @@ class _$_ExecutableDeclarationStorageV3
         _entryPoints = entryPoints,
         super._();
 
-  factory _$_ExecutableDeclarationStorageV3.fromJson(
+  factory _$ExecutableDeclarationStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_ExecutableDeclarationStorageV3FromJson(json);
+      _$$ExecutableDeclarationStorageV3ImplFromJson(json);
 
   @override
   final String returnTypeName;
@@ -580,7 +581,7 @@ class _$_ExecutableDeclarationStorageV3
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_ExecutableDeclarationStorageV3 &&
+            other is _$ExecutableDeclarationStorageV3Impl &&
             (identical(other.returnTypeName, returnTypeName) ||
                 other.returnTypeName == returnTypeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -619,13 +620,14 @@ class _$_ExecutableDeclarationStorageV3
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_ExecutableDeclarationStorageV3CopyWith<_$_ExecutableDeclarationStorageV3>
-      get copyWith => __$$_ExecutableDeclarationStorageV3CopyWithImpl<
-          _$_ExecutableDeclarationStorageV3>(this, _$identity);
+  _$$ExecutableDeclarationStorageV3ImplCopyWith<
+          _$ExecutableDeclarationStorageV3Impl>
+      get copyWith => __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<
+          _$ExecutableDeclarationStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_ExecutableDeclarationStorageV3ToJson(
+    return _$$ExecutableDeclarationStorageV3ImplToJson(
       this,
     );
   }
@@ -643,11 +645,12 @@ abstract class _ExecutableDeclarationStorageV3
       required final ExecutableTypeStorageV3 type,
       required final bool isStatic,
       required final Set<String> entryPoints,
-      required final String relativePath}) = _$_ExecutableDeclarationStorageV3;
+      required final String
+          relativePath}) = _$ExecutableDeclarationStorageV3Impl;
   const _ExecutableDeclarationStorageV3._() : super._();
 
   factory _ExecutableDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_ExecutableDeclarationStorageV3.fromJson;
+      _$ExecutableDeclarationStorageV3Impl.fromJson;
 
   @override
   String get returnTypeName;
@@ -671,6 +674,7 @@ abstract class _ExecutableDeclarationStorageV3
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_ExecutableDeclarationStorageV3CopyWith<_$_ExecutableDeclarationStorageV3>
+  _$$ExecutableDeclarationStorageV3ImplCopyWith<
+          _$ExecutableDeclarationStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/executable_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.g.dart
@@ -8,10 +8,10 @@ part of 'executable_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_ExecutableParameterDeclarationStorageV3
-    _$$_ExecutableParameterDeclarationStorageV3FromJson(
+_$ExecutableParameterDeclarationStorageV3Impl
+    _$$ExecutableParameterDeclarationStorageV3ImplFromJson(
             Map<String, dynamic> json) =>
-        _$_ExecutableParameterDeclarationStorageV3(
+        _$ExecutableParameterDeclarationStorageV3Impl(
           isRequired: json['isRequired'] as bool,
           isNamed: json['isNamed'] as bool,
           name: json['name'] as String,
@@ -21,8 +21,8 @@ _$_ExecutableParameterDeclarationStorageV3
           relativePath: json['relativePath'] as String,
         );
 
-Map<String, dynamic> _$$_ExecutableParameterDeclarationStorageV3ToJson(
-        _$_ExecutableParameterDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$ExecutableParameterDeclarationStorageV3ImplToJson(
+        _$ExecutableParameterDeclarationStorageV3Impl instance) =>
     <String, dynamic>{
       'isRequired': instance.isRequired,
       'isNamed': instance.isNamed,
@@ -33,30 +33,30 @@ Map<String, dynamic> _$$_ExecutableParameterDeclarationStorageV3ToJson(
       'relativePath': instance.relativePath,
     };
 
-_$_ExecutableDeclarationStorageV3 _$$_ExecutableDeclarationStorageV3FromJson(
-        Map<String, dynamic> json) =>
-    _$_ExecutableDeclarationStorageV3(
-      returnTypeName: json['returnTypeName'] as String,
-      name: json['name'] as String,
-      isDeprecated: json['isDeprecated'] as bool,
-      isExperimental: json['isExperimental'] as bool,
-      parameters: (json['parameters'] as List<dynamic>)
-          .map((e) => ExecutableParameterDeclarationStorageV3.fromJson(
-              e as Map<String, dynamic>))
-          .toList(),
-      typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
-      type: $enumDecode(_$ExecutableTypeStorageV3EnumMap, json['type']),
-      isStatic: json['isStatic'] as bool,
-      entryPoints: (json['entryPoints'] as List<dynamic>)
-          .map((e) => e as String)
-          .toSet(),
-      relativePath: json['relativePath'] as String,
-    );
+_$ExecutableDeclarationStorageV3Impl
+    _$$ExecutableDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
+        _$ExecutableDeclarationStorageV3Impl(
+          returnTypeName: json['returnTypeName'] as String,
+          name: json['name'] as String,
+          isDeprecated: json['isDeprecated'] as bool,
+          isExperimental: json['isExperimental'] as bool,
+          parameters: (json['parameters'] as List<dynamic>)
+              .map((e) => ExecutableParameterDeclarationStorageV3.fromJson(
+                  e as Map<String, dynamic>))
+              .toList(),
+          typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
+              .map((e) => e as String)
+              .toList(),
+          type: $enumDecode(_$ExecutableTypeStorageV3EnumMap, json['type']),
+          isStatic: json['isStatic'] as bool,
+          entryPoints: (json['entryPoints'] as List<dynamic>)
+              .map((e) => e as String)
+              .toSet(),
+          relativePath: json['relativePath'] as String,
+        );
 
-Map<String, dynamic> _$$_ExecutableDeclarationStorageV3ToJson(
-        _$_ExecutableDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$ExecutableDeclarationStorageV3ImplToJson(
+        _$ExecutableDeclarationStorageV3Impl instance) =>
     <String, dynamic>{
       'returnTypeName': instance.returnTypeName,
       'name': instance.name,

--- a/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
@@ -107,12 +107,12 @@ class _$FieldDeclarationStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
+abstract class _$$FieldDeclarationStorageV3ImplCopyWith<$Res>
     implements $FieldDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_FieldDeclarationStorageV3CopyWith(
-          _$_FieldDeclarationStorageV3 value,
-          $Res Function(_$_FieldDeclarationStorageV3) then) =
-      __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>;
+  factory _$$FieldDeclarationStorageV3ImplCopyWith(
+          _$FieldDeclarationStorageV3Impl value,
+          $Res Function(_$FieldDeclarationStorageV3Impl) then) =
+      __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -126,13 +126,13 @@ abstract class _$$_FieldDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>
+class __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>
     extends _$FieldDeclarationStorageV3CopyWithImpl<$Res,
-        _$_FieldDeclarationStorageV3>
-    implements _$$_FieldDeclarationStorageV3CopyWith<$Res> {
-  __$$_FieldDeclarationStorageV3CopyWithImpl(
-      _$_FieldDeclarationStorageV3 _value,
-      $Res Function(_$_FieldDeclarationStorageV3) _then)
+        _$FieldDeclarationStorageV3Impl>
+    implements _$$FieldDeclarationStorageV3ImplCopyWith<$Res> {
+  __$$FieldDeclarationStorageV3ImplCopyWithImpl(
+      _$FieldDeclarationStorageV3Impl _value,
+      $Res Function(_$FieldDeclarationStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -146,7 +146,7 @@ class __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$_FieldDeclarationStorageV3(
+    return _then(_$FieldDeclarationStorageV3Impl(
       typeName: null == typeName
           ? _value.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
@@ -181,8 +181,8 @@ class __$$_FieldDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
-  const _$_FieldDeclarationStorageV3(
+class _$FieldDeclarationStorageV3Impl extends _FieldDeclarationStorageV3 {
+  const _$FieldDeclarationStorageV3Impl(
       {required this.typeName,
       required this.name,
       required this.isDeprecated,
@@ -193,8 +193,8 @@ class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
       : _entryPoints = entryPoints,
         super._();
 
-  factory _$_FieldDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
-      _$$_FieldDeclarationStorageV3FromJson(json);
+  factory _$FieldDeclarationStorageV3Impl.fromJson(Map<String, dynamic> json) =>
+      _$$FieldDeclarationStorageV3ImplFromJson(json);
 
   @override
   final String typeName;
@@ -226,7 +226,7 @@ class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FieldDeclarationStorageV3 &&
+            other is _$FieldDeclarationStorageV3Impl &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -257,13 +257,13 @@ class _$_FieldDeclarationStorageV3 extends _FieldDeclarationStorageV3 {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FieldDeclarationStorageV3CopyWith<_$_FieldDeclarationStorageV3>
-      get copyWith => __$$_FieldDeclarationStorageV3CopyWithImpl<
-          _$_FieldDeclarationStorageV3>(this, _$identity);
+  _$$FieldDeclarationStorageV3ImplCopyWith<_$FieldDeclarationStorageV3Impl>
+      get copyWith => __$$FieldDeclarationStorageV3ImplCopyWithImpl<
+          _$FieldDeclarationStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_FieldDeclarationStorageV3ToJson(
+    return _$$FieldDeclarationStorageV3ImplToJson(
       this,
     );
   }
@@ -277,11 +277,11 @@ abstract class _FieldDeclarationStorageV3 extends FieldDeclarationStorageV3 {
       required final bool isExperimental,
       required final bool isStatic,
       required final Set<String> entryPoints,
-      required final String relativePath}) = _$_FieldDeclarationStorageV3;
+      required final String relativePath}) = _$FieldDeclarationStorageV3Impl;
   const _FieldDeclarationStorageV3._() : super._();
 
   factory _FieldDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_FieldDeclarationStorageV3.fromJson;
+      _$FieldDeclarationStorageV3Impl.fromJson;
 
   @override
   String get typeName;
@@ -299,6 +299,6 @@ abstract class _FieldDeclarationStorageV3 extends FieldDeclarationStorageV3 {
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_FieldDeclarationStorageV3CopyWith<_$_FieldDeclarationStorageV3>
+  _$$FieldDeclarationStorageV3ImplCopyWith<_$FieldDeclarationStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/field_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.g.dart
@@ -8,9 +8,9 @@ part of 'field_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_FieldDeclarationStorageV3 _$$_FieldDeclarationStorageV3FromJson(
+_$FieldDeclarationStorageV3Impl _$$FieldDeclarationStorageV3ImplFromJson(
         Map<String, dynamic> json) =>
-    _$_FieldDeclarationStorageV3(
+    _$FieldDeclarationStorageV3Impl(
       typeName: json['typeName'] as String,
       name: json['name'] as String,
       isDeprecated: json['isDeprecated'] as bool,
@@ -22,8 +22,8 @@ _$_FieldDeclarationStorageV3 _$$_FieldDeclarationStorageV3FromJson(
       relativePath: json['relativePath'] as String,
     );
 
-Map<String, dynamic> _$$_FieldDeclarationStorageV3ToJson(
-        _$_FieldDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$FieldDeclarationStorageV3ImplToJson(
+        _$FieldDeclarationStorageV3Impl instance) =>
     <String, dynamic>{
       'typeName': instance.typeName,
       'name': instance.name,

--- a/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
@@ -139,12 +139,12 @@ class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
+abstract class _$$InterfaceDeclarationStorageV3ImplCopyWith<$Res>
     implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_InterfaceDeclarationStorageV3CopyWith(
-          _$_InterfaceDeclarationStorageV3 value,
-          $Res Function(_$_InterfaceDeclarationStorageV3) then) =
-      __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>;
+  factory _$$InterfaceDeclarationStorageV3ImplCopyWith(
+          _$InterfaceDeclarationStorageV3Impl value,
+          $Res Function(_$InterfaceDeclarationStorageV3Impl) then) =
+      __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -162,13 +162,13 @@ abstract class _$$_InterfaceDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+class __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>
     extends _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
-        _$_InterfaceDeclarationStorageV3>
-    implements _$$_InterfaceDeclarationStorageV3CopyWith<$Res> {
-  __$$_InterfaceDeclarationStorageV3CopyWithImpl(
-      _$_InterfaceDeclarationStorageV3 _value,
-      $Res Function(_$_InterfaceDeclarationStorageV3) _then)
+        _$InterfaceDeclarationStorageV3Impl>
+    implements _$$InterfaceDeclarationStorageV3ImplCopyWith<$Res> {
+  __$$InterfaceDeclarationStorageV3ImplCopyWithImpl(
+      _$InterfaceDeclarationStorageV3Impl _value,
+      $Res Function(_$InterfaceDeclarationStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -186,7 +186,7 @@ class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$_InterfaceDeclarationStorageV3(
+    return _then(_$InterfaceDeclarationStorageV3Impl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -237,8 +237,9 @@ class __$$_InterfaceDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
-  const _$_InterfaceDeclarationStorageV3(
+class _$InterfaceDeclarationStorageV3Impl
+    extends _InterfaceDeclarationStorageV3 {
+  const _$InterfaceDeclarationStorageV3Impl(
       {required this.name,
       required this.isDeprecated,
       required this.isExperimental,
@@ -258,9 +259,9 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
         _entryPoints = entryPoints,
         super._();
 
-  factory _$_InterfaceDeclarationStorageV3.fromJson(
+  factory _$InterfaceDeclarationStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_InterfaceDeclarationStorageV3FromJson(json);
+      _$$InterfaceDeclarationStorageV3ImplFromJson(json);
 
   @override
   final String name;
@@ -327,7 +328,7 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_InterfaceDeclarationStorageV3 &&
+            other is _$InterfaceDeclarationStorageV3Impl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
@@ -370,13 +371,14 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_InterfaceDeclarationStorageV3CopyWith<_$_InterfaceDeclarationStorageV3>
-      get copyWith => __$$_InterfaceDeclarationStorageV3CopyWithImpl<
-          _$_InterfaceDeclarationStorageV3>(this, _$identity);
+  _$$InterfaceDeclarationStorageV3ImplCopyWith<
+          _$InterfaceDeclarationStorageV3Impl>
+      get copyWith => __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<
+          _$InterfaceDeclarationStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_InterfaceDeclarationStorageV3ToJson(
+    return _$$InterfaceDeclarationStorageV3ImplToJson(
       this,
     );
   }
@@ -385,22 +387,23 @@ class _$_InterfaceDeclarationStorageV3 extends _InterfaceDeclarationStorageV3 {
 abstract class _InterfaceDeclarationStorageV3
     extends InterfaceDeclarationStorageV3 {
   const factory _InterfaceDeclarationStorageV3(
-      {required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final bool isSealed,
-      required final bool isRequired,
-      required final List<String> typeParameterNames,
-      required final List<String> superTypeNames,
-      required final List<ExecutableDeclarationStorageV3>
-          executableDeclarations,
-      required final List<FieldDeclarationStorageV3> fieldDeclarations,
-      required final Set<String> entryPoints,
-      required final String relativePath}) = _$_InterfaceDeclarationStorageV3;
+          {required final String name,
+          required final bool isDeprecated,
+          required final bool isExperimental,
+          required final bool isSealed,
+          required final bool isRequired,
+          required final List<String> typeParameterNames,
+          required final List<String> superTypeNames,
+          required final List<ExecutableDeclarationStorageV3>
+              executableDeclarations,
+          required final List<FieldDeclarationStorageV3> fieldDeclarations,
+          required final Set<String> entryPoints,
+          required final String relativePath}) =
+      _$InterfaceDeclarationStorageV3Impl;
   const _InterfaceDeclarationStorageV3._() : super._();
 
   factory _InterfaceDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_InterfaceDeclarationStorageV3.fromJson;
+      _$InterfaceDeclarationStorageV3Impl.fromJson;
 
   @override
   String get name;
@@ -426,6 +429,7 @@ abstract class _InterfaceDeclarationStorageV3
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_InterfaceDeclarationStorageV3CopyWith<_$_InterfaceDeclarationStorageV3>
+  _$$InterfaceDeclarationStorageV3ImplCopyWith<
+          _$InterfaceDeclarationStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
@@ -8,36 +8,37 @@ part of 'interface_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_InterfaceDeclarationStorageV3 _$$_InterfaceDeclarationStorageV3FromJson(
-        Map<String, dynamic> json) =>
-    _$_InterfaceDeclarationStorageV3(
-      name: json['name'] as String,
-      isDeprecated: json['isDeprecated'] as bool,
-      isExperimental: json['isExperimental'] as bool,
-      isSealed: json['isSealed'] as bool,
-      isRequired: json['isRequired'] as bool,
-      typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
-      superTypeNames: (json['superTypeNames'] as List<dynamic>)
-          .map((e) => e as String)
-          .toList(),
-      executableDeclarations: (json['executableDeclarations'] as List<dynamic>)
-          .map((e) => ExecutableDeclarationStorageV3.fromJson(
-              e as Map<String, dynamic>))
-          .toList(),
-      fieldDeclarations: (json['fieldDeclarations'] as List<dynamic>)
-          .map((e) =>
-              FieldDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      entryPoints: (json['entryPoints'] as List<dynamic>)
-          .map((e) => e as String)
-          .toSet(),
-      relativePath: json['relativePath'] as String,
-    );
+_$InterfaceDeclarationStorageV3Impl
+    _$$InterfaceDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
+        _$InterfaceDeclarationStorageV3Impl(
+          name: json['name'] as String,
+          isDeprecated: json['isDeprecated'] as bool,
+          isExperimental: json['isExperimental'] as bool,
+          isSealed: json['isSealed'] as bool,
+          isRequired: json['isRequired'] as bool,
+          typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
+              .map((e) => e as String)
+              .toList(),
+          superTypeNames: (json['superTypeNames'] as List<dynamic>)
+              .map((e) => e as String)
+              .toList(),
+          executableDeclarations:
+              (json['executableDeclarations'] as List<dynamic>)
+                  .map((e) => ExecutableDeclarationStorageV3.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList(),
+          fieldDeclarations: (json['fieldDeclarations'] as List<dynamic>)
+              .map((e) =>
+                  FieldDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
+              .toList(),
+          entryPoints: (json['entryPoints'] as List<dynamic>)
+              .map((e) => e as String)
+              .toSet(),
+          relativePath: json['relativePath'] as String,
+        );
 
-Map<String, dynamic> _$$_InterfaceDeclarationStorageV3ToJson(
-        _$_InterfaceDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$InterfaceDeclarationStorageV3ImplToJson(
+        _$InterfaceDeclarationStorageV3Impl instance) =>
     <String, dynamic>{
       'name': instance.name,
       'isDeprecated': instance.isDeprecated,

--- a/lib/src/storage/v3/package_api_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.freezed.dart
@@ -186,11 +186,11 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
 }
 
 /// @nodoc
-abstract class _$$_PackageApiStorageV3CopyWith<$Res>
+abstract class _$$PackageApiStorageV3ImplCopyWith<$Res>
     implements $PackageApiStorageV3CopyWith<$Res> {
-  factory _$$_PackageApiStorageV3CopyWith(_$_PackageApiStorageV3 value,
-          $Res Function(_$_PackageApiStorageV3) then) =
-      __$$_PackageApiStorageV3CopyWithImpl<$Res>;
+  factory _$$PackageApiStorageV3ImplCopyWith(_$PackageApiStorageV3Impl value,
+          $Res Function(_$PackageApiStorageV3Impl) then) =
+      __$$PackageApiStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -216,11 +216,11 @@ abstract class _$$_PackageApiStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_PackageApiStorageV3CopyWithImpl<$Res>
-    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$_PackageApiStorageV3>
-    implements _$$_PackageApiStorageV3CopyWith<$Res> {
-  __$$_PackageApiStorageV3CopyWithImpl(_$_PackageApiStorageV3 _value,
-      $Res Function(_$_PackageApiStorageV3) _then)
+class __$$PackageApiStorageV3ImplCopyWithImpl<$Res>
+    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$PackageApiStorageV3Impl>
+    implements _$$PackageApiStorageV3ImplCopyWith<$Res> {
+  __$$PackageApiStorageV3ImplCopyWithImpl(_$PackageApiStorageV3Impl _value,
+      $Res Function(_$PackageApiStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -240,7 +240,7 @@ class __$$_PackageApiStorageV3CopyWithImpl<$Res>
     Object? minSdkVersion = null,
     Object? packageDependencies = null,
   }) {
-    return _then(_$_PackageApiStorageV3(
+    return _then(_$PackageApiStorageV3Impl(
       packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
@@ -299,8 +299,8 @@ class __$$_PackageApiStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
-  const _$_PackageApiStorageV3(
+class _$PackageApiStorageV3Impl extends _PackageApiStorageV3 {
+  const _$PackageApiStorageV3Impl(
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
@@ -323,8 +323,8 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
         _packageDependencies = packageDependencies,
         super._();
 
-  factory _$_PackageApiStorageV3.fromJson(Map<String, dynamic> json) =>
-      _$$_PackageApiStorageV3FromJson(json);
+  factory _$PackageApiStorageV3Impl.fromJson(Map<String, dynamic> json) =>
+      _$$PackageApiStorageV3ImplFromJson(json);
 
   @override
   final String packageName;
@@ -403,7 +403,7 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PackageApiStorageV3 &&
+            other is _$PackageApiStorageV3Impl &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -454,13 +454,13 @@ class _$_PackageApiStorageV3 extends _PackageApiStorageV3 {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PackageApiStorageV3CopyWith<_$_PackageApiStorageV3> get copyWith =>
-      __$$_PackageApiStorageV3CopyWithImpl<_$_PackageApiStorageV3>(
+  _$$PackageApiStorageV3ImplCopyWith<_$PackageApiStorageV3Impl> get copyWith =>
+      __$$PackageApiStorageV3ImplCopyWithImpl<_$PackageApiStorageV3Impl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PackageApiStorageV3ToJson(
+    return _$$PackageApiStorageV3ImplToJson(
       this,
     );
   }
@@ -482,11 +482,11 @@ abstract class _PackageApiStorageV3 extends PackageApiStorageV3 {
       required final SdkTypeStorageV3 sdkType,
       @VersionJsonConverter() required final Version minSdkVersion,
       required final List<PackageDependencyStorageV3>
-          packageDependencies}) = _$_PackageApiStorageV3;
+          packageDependencies}) = _$PackageApiStorageV3Impl;
   const _PackageApiStorageV3._() : super._();
 
   factory _PackageApiStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_PackageApiStorageV3.fromJson;
+      _$PackageApiStorageV3Impl.fromJson;
 
   @override
   String get packageName;
@@ -517,6 +517,6 @@ abstract class _PackageApiStorageV3 extends PackageApiStorageV3 {
   List<PackageDependencyStorageV3> get packageDependencies;
   @override
   @JsonKey(ignore: true)
-  _$$_PackageApiStorageV3CopyWith<_$_PackageApiStorageV3> get copyWith =>
+  _$$PackageApiStorageV3ImplCopyWith<_$PackageApiStorageV3Impl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/package_api_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.g.dart
@@ -8,9 +8,9 @@ part of 'package_api_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PackageApiStorageV3 _$$_PackageApiStorageV3FromJson(
+_$PackageApiStorageV3Impl _$$PackageApiStorageV3ImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PackageApiStorageV3(
+    _$PackageApiStorageV3Impl(
       packageName: json['packageName'] as String,
       packageVersion: json['packageVersion'] as String?,
       packagePath: json['packagePath'] as String,
@@ -50,8 +50,8 @@ _$_PackageApiStorageV3 _$$_PackageApiStorageV3FromJson(
           .toList(),
     );
 
-Map<String, dynamic> _$$_PackageApiStorageV3ToJson(
-        _$_PackageApiStorageV3 instance) =>
+Map<String, dynamic> _$$PackageApiStorageV3ImplToJson(
+        _$PackageApiStorageV3Impl instance) =>
     <String, dynamic>{
       'packageName': instance.packageName,
       'packageVersion': instance.packageVersion,

--- a/lib/src/storage/v3/package_dependency_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_dependency_storage_v3.freezed.dart
@@ -71,25 +71,25 @@ class _$PackageDependencyStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_PackageDependencyStorageV3CopyWith<$Res>
+abstract class _$$PackageDependencyStorageV3ImplCopyWith<$Res>
     implements $PackageDependencyStorageV3CopyWith<$Res> {
-  factory _$$_PackageDependencyStorageV3CopyWith(
-          _$_PackageDependencyStorageV3 value,
-          $Res Function(_$_PackageDependencyStorageV3) then) =
-      __$$_PackageDependencyStorageV3CopyWithImpl<$Res>;
+  factory _$$PackageDependencyStorageV3ImplCopyWith(
+          _$PackageDependencyStorageV3Impl value,
+          $Res Function(_$PackageDependencyStorageV3Impl) then) =
+      __$$PackageDependencyStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({String packageName, String? packageVersion});
 }
 
 /// @nodoc
-class __$$_PackageDependencyStorageV3CopyWithImpl<$Res>
+class __$$PackageDependencyStorageV3ImplCopyWithImpl<$Res>
     extends _$PackageDependencyStorageV3CopyWithImpl<$Res,
-        _$_PackageDependencyStorageV3>
-    implements _$$_PackageDependencyStorageV3CopyWith<$Res> {
-  __$$_PackageDependencyStorageV3CopyWithImpl(
-      _$_PackageDependencyStorageV3 _value,
-      $Res Function(_$_PackageDependencyStorageV3) _then)
+        _$PackageDependencyStorageV3Impl>
+    implements _$$PackageDependencyStorageV3ImplCopyWith<$Res> {
+  __$$PackageDependencyStorageV3ImplCopyWithImpl(
+      _$PackageDependencyStorageV3Impl _value,
+      $Res Function(_$PackageDependencyStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -98,7 +98,7 @@ class __$$_PackageDependencyStorageV3CopyWithImpl<$Res>
     Object? packageName = null,
     Object? packageVersion = freezed,
   }) {
-    return _then(_$_PackageDependencyStorageV3(
+    return _then(_$PackageDependencyStorageV3Impl(
       packageName: null == packageName
           ? _value.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
@@ -113,13 +113,14 @@ class __$$_PackageDependencyStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_PackageDependencyStorageV3 extends _PackageDependencyStorageV3 {
-  const _$_PackageDependencyStorageV3(
+class _$PackageDependencyStorageV3Impl extends _PackageDependencyStorageV3 {
+  const _$PackageDependencyStorageV3Impl(
       {required this.packageName, required this.packageVersion})
       : super._();
 
-  factory _$_PackageDependencyStorageV3.fromJson(Map<String, dynamic> json) =>
-      _$$_PackageDependencyStorageV3FromJson(json);
+  factory _$PackageDependencyStorageV3Impl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$PackageDependencyStorageV3ImplFromJson(json);
 
   @override
   final String packageName;
@@ -135,7 +136,7 @@ class _$_PackageDependencyStorageV3 extends _PackageDependencyStorageV3 {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_PackageDependencyStorageV3 &&
+            other is _$PackageDependencyStorageV3Impl &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -149,13 +150,13 @@ class _$_PackageDependencyStorageV3 extends _PackageDependencyStorageV3 {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_PackageDependencyStorageV3CopyWith<_$_PackageDependencyStorageV3>
-      get copyWith => __$$_PackageDependencyStorageV3CopyWithImpl<
-          _$_PackageDependencyStorageV3>(this, _$identity);
+  _$$PackageDependencyStorageV3ImplCopyWith<_$PackageDependencyStorageV3Impl>
+      get copyWith => __$$PackageDependencyStorageV3ImplCopyWithImpl<
+          _$PackageDependencyStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_PackageDependencyStorageV3ToJson(
+    return _$$PackageDependencyStorageV3ImplToJson(
       this,
     );
   }
@@ -163,12 +164,13 @@ class _$_PackageDependencyStorageV3 extends _PackageDependencyStorageV3 {
 
 abstract class _PackageDependencyStorageV3 extends PackageDependencyStorageV3 {
   const factory _PackageDependencyStorageV3(
-      {required final String packageName,
-      required final String? packageVersion}) = _$_PackageDependencyStorageV3;
+          {required final String packageName,
+          required final String? packageVersion}) =
+      _$PackageDependencyStorageV3Impl;
   const _PackageDependencyStorageV3._() : super._();
 
   factory _PackageDependencyStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_PackageDependencyStorageV3.fromJson;
+      _$PackageDependencyStorageV3Impl.fromJson;
 
   @override
   String get packageName;
@@ -176,6 +178,6 @@ abstract class _PackageDependencyStorageV3 extends PackageDependencyStorageV3 {
   String? get packageVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_PackageDependencyStorageV3CopyWith<_$_PackageDependencyStorageV3>
+  _$$PackageDependencyStorageV3ImplCopyWith<_$PackageDependencyStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/package_dependency_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_dependency_storage_v3.g.dart
@@ -8,15 +8,15 @@ part of 'package_dependency_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_PackageDependencyStorageV3 _$$_PackageDependencyStorageV3FromJson(
+_$PackageDependencyStorageV3Impl _$$PackageDependencyStorageV3ImplFromJson(
         Map<String, dynamic> json) =>
-    _$_PackageDependencyStorageV3(
+    _$PackageDependencyStorageV3Impl(
       packageName: json['packageName'] as String,
       packageVersion: json['packageVersion'] as String?,
     );
 
-Map<String, dynamic> _$$_PackageDependencyStorageV3ToJson(
-        _$_PackageDependencyStorageV3 instance) =>
+Map<String, dynamic> _$$PackageDependencyStorageV3ImplToJson(
+        _$PackageDependencyStorageV3Impl instance) =>
     <String, dynamic>{
       'packageName': instance.packageName,
       'packageVersion': instance.packageVersion,

--- a/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
@@ -66,25 +66,25 @@ class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res>
+abstract class _$$IOSPlatformConstraintsStorageV3ImplCopyWith<$Res>
     implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory _$$_IOSPlatformConstraintsStorageV3CopyWith(
-          _$_IOSPlatformConstraintsStorageV3 value,
-          $Res Function(_$_IOSPlatformConstraintsStorageV3) then) =
-      __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>;
+  factory _$$IOSPlatformConstraintsStorageV3ImplCopyWith(
+          _$IOSPlatformConstraintsStorageV3Impl value,
+          $Res Function(_$IOSPlatformConstraintsStorageV3Impl) then) =
+      __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
+class __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>
     extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$_IOSPlatformConstraintsStorageV3>
-    implements _$$_IOSPlatformConstraintsStorageV3CopyWith<$Res> {
-  __$$_IOSPlatformConstraintsStorageV3CopyWithImpl(
-      _$_IOSPlatformConstraintsStorageV3 _value,
-      $Res Function(_$_IOSPlatformConstraintsStorageV3) _then)
+        _$IOSPlatformConstraintsStorageV3Impl>
+    implements _$$IOSPlatformConstraintsStorageV3ImplCopyWith<$Res> {
+  __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl(
+      _$IOSPlatformConstraintsStorageV3Impl _value,
+      $Res Function(_$IOSPlatformConstraintsStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -92,7 +92,7 @@ class __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
   $Res call({
     Object? minimumOsVersion = freezed,
   }) {
-    return _then(_$_IOSPlatformConstraintsStorageV3(
+    return _then(_$IOSPlatformConstraintsStorageV3Impl(
       minimumOsVersion: freezed == minimumOsVersion
           ? _value.minimumOsVersion
           : minimumOsVersion // ignore: cast_nullable_to_non_nullable
@@ -103,14 +103,14 @@ class __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_IOSPlatformConstraintsStorageV3
+class _$IOSPlatformConstraintsStorageV3Impl
     extends _IOSPlatformConstraintsStorageV3 {
-  const _$_IOSPlatformConstraintsStorageV3({required this.minimumOsVersion})
+  const _$IOSPlatformConstraintsStorageV3Impl({required this.minimumOsVersion})
       : super._();
 
-  factory _$_IOSPlatformConstraintsStorageV3.fromJson(
+  factory _$IOSPlatformConstraintsStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_IOSPlatformConstraintsStorageV3FromJson(json);
+      _$$IOSPlatformConstraintsStorageV3ImplFromJson(json);
 
   @override
   final num? minimumOsVersion;
@@ -124,7 +124,7 @@ class _$_IOSPlatformConstraintsStorageV3
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_IOSPlatformConstraintsStorageV3 &&
+            other is _$IOSPlatformConstraintsStorageV3Impl &&
             (identical(other.minimumOsVersion, minimumOsVersion) ||
                 other.minimumOsVersion == minimumOsVersion));
   }
@@ -136,14 +136,14 @@ class _$_IOSPlatformConstraintsStorageV3
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_IOSPlatformConstraintsStorageV3CopyWith<
-          _$_IOSPlatformConstraintsStorageV3>
-      get copyWith => __$$_IOSPlatformConstraintsStorageV3CopyWithImpl<
-          _$_IOSPlatformConstraintsStorageV3>(this, _$identity);
+  _$$IOSPlatformConstraintsStorageV3ImplCopyWith<
+          _$IOSPlatformConstraintsStorageV3Impl>
+      get copyWith => __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<
+          _$IOSPlatformConstraintsStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_IOSPlatformConstraintsStorageV3ToJson(
+    return _$$IOSPlatformConstraintsStorageV3ImplToJson(
       this,
     );
   }
@@ -153,18 +153,18 @@ abstract class _IOSPlatformConstraintsStorageV3
     extends IOSPlatformConstraintsStorageV3 {
   const factory _IOSPlatformConstraintsStorageV3(
           {required final num? minimumOsVersion}) =
-      _$_IOSPlatformConstraintsStorageV3;
+      _$IOSPlatformConstraintsStorageV3Impl;
   const _IOSPlatformConstraintsStorageV3._() : super._();
 
   factory _IOSPlatformConstraintsStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_IOSPlatformConstraintsStorageV3.fromJson;
+      _$IOSPlatformConstraintsStorageV3Impl.fromJson;
 
   @override
   num? get minimumOsVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_IOSPlatformConstraintsStorageV3CopyWith<
-          _$_IOSPlatformConstraintsStorageV3>
+  _$$IOSPlatformConstraintsStorageV3ImplCopyWith<
+          _$IOSPlatformConstraintsStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -234,12 +234,12 @@ class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res>
+abstract class _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<$Res>
     implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory _$$_AndroidPlatformConstraintsStorageV3CopyWith(
-          _$_AndroidPlatformConstraintsStorageV3 value,
-          $Res Function(_$_AndroidPlatformConstraintsStorageV3) then) =
-      __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>;
+  factory _$$AndroidPlatformConstraintsStorageV3ImplCopyWith(
+          _$AndroidPlatformConstraintsStorageV3Impl value,
+          $Res Function(_$AndroidPlatformConstraintsStorageV3Impl) then) =
+      __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -247,13 +247,13 @@ abstract class _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
+class __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>
     extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$_AndroidPlatformConstraintsStorageV3>
-    implements _$$_AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
-  __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl(
-      _$_AndroidPlatformConstraintsStorageV3 _value,
-      $Res Function(_$_AndroidPlatformConstraintsStorageV3) _then)
+        _$AndroidPlatformConstraintsStorageV3Impl>
+    implements _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<$Res> {
+  __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl(
+      _$AndroidPlatformConstraintsStorageV3Impl _value,
+      $Res Function(_$AndroidPlatformConstraintsStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -263,7 +263,7 @@ class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
     Object? compileSdkVersion = freezed,
     Object? targetSdkVersion = freezed,
   }) {
-    return _then(_$_AndroidPlatformConstraintsStorageV3(
+    return _then(_$AndroidPlatformConstraintsStorageV3Impl(
       minSdkVersion: freezed == minSdkVersion
           ? _value.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
@@ -282,17 +282,17 @@ class __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_AndroidPlatformConstraintsStorageV3
+class _$AndroidPlatformConstraintsStorageV3Impl
     extends _AndroidPlatformConstraintsStorageV3 {
-  const _$_AndroidPlatformConstraintsStorageV3(
+  const _$AndroidPlatformConstraintsStorageV3Impl(
       {required this.minSdkVersion,
       required this.compileSdkVersion,
       required this.targetSdkVersion})
       : super._();
 
-  factory _$_AndroidPlatformConstraintsStorageV3.fromJson(
+  factory _$AndroidPlatformConstraintsStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_AndroidPlatformConstraintsStorageV3FromJson(json);
+      _$$AndroidPlatformConstraintsStorageV3ImplFromJson(json);
 
   @override
   final int? minSdkVersion;
@@ -310,7 +310,7 @@ class _$_AndroidPlatformConstraintsStorageV3
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_AndroidPlatformConstraintsStorageV3 &&
+            other is _$AndroidPlatformConstraintsStorageV3Impl &&
             (identical(other.minSdkVersion, minSdkVersion) ||
                 other.minSdkVersion == minSdkVersion) &&
             (identical(other.compileSdkVersion, compileSdkVersion) ||
@@ -327,14 +327,14 @@ class _$_AndroidPlatformConstraintsStorageV3
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_AndroidPlatformConstraintsStorageV3CopyWith<
-          _$_AndroidPlatformConstraintsStorageV3>
-      get copyWith => __$$_AndroidPlatformConstraintsStorageV3CopyWithImpl<
-          _$_AndroidPlatformConstraintsStorageV3>(this, _$identity);
+  _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<
+          _$AndroidPlatformConstraintsStorageV3Impl>
+      get copyWith => __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<
+          _$AndroidPlatformConstraintsStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_AndroidPlatformConstraintsStorageV3ToJson(
+    return _$$AndroidPlatformConstraintsStorageV3ImplToJson(
       this,
     );
   }
@@ -346,12 +346,12 @@ abstract class _AndroidPlatformConstraintsStorageV3
           {required final int? minSdkVersion,
           required final int? compileSdkVersion,
           required final int? targetSdkVersion}) =
-      _$_AndroidPlatformConstraintsStorageV3;
+      _$AndroidPlatformConstraintsStorageV3Impl;
   const _AndroidPlatformConstraintsStorageV3._() : super._();
 
   factory _AndroidPlatformConstraintsStorageV3.fromJson(
           Map<String, dynamic> json) =
-      _$_AndroidPlatformConstraintsStorageV3.fromJson;
+      _$AndroidPlatformConstraintsStorageV3Impl.fromJson;
 
   @override
   int? get minSdkVersion;
@@ -361,7 +361,7 @@ abstract class _AndroidPlatformConstraintsStorageV3
   int? get targetSdkVersion;
   @override
   @JsonKey(ignore: true)
-  _$$_AndroidPlatformConstraintsStorageV3CopyWith<
-          _$_AndroidPlatformConstraintsStorageV3>
+  _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<
+          _$AndroidPlatformConstraintsStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/platform_constraints_storage_v3.g.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.g.dart
@@ -8,29 +8,29 @@ part of 'platform_constraints_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_IOSPlatformConstraintsStorageV3 _$$_IOSPlatformConstraintsStorageV3FromJson(
-        Map<String, dynamic> json) =>
-    _$_IOSPlatformConstraintsStorageV3(
-      minimumOsVersion: json['minimumOsVersion'] as num?,
-    );
+_$IOSPlatformConstraintsStorageV3Impl
+    _$$IOSPlatformConstraintsStorageV3ImplFromJson(Map<String, dynamic> json) =>
+        _$IOSPlatformConstraintsStorageV3Impl(
+          minimumOsVersion: json['minimumOsVersion'] as num?,
+        );
 
-Map<String, dynamic> _$$_IOSPlatformConstraintsStorageV3ToJson(
-        _$_IOSPlatformConstraintsStorageV3 instance) =>
+Map<String, dynamic> _$$IOSPlatformConstraintsStorageV3ImplToJson(
+        _$IOSPlatformConstraintsStorageV3Impl instance) =>
     <String, dynamic>{
       'minimumOsVersion': instance.minimumOsVersion,
     };
 
-_$_AndroidPlatformConstraintsStorageV3
-    _$$_AndroidPlatformConstraintsStorageV3FromJson(
+_$AndroidPlatformConstraintsStorageV3Impl
+    _$$AndroidPlatformConstraintsStorageV3ImplFromJson(
             Map<String, dynamic> json) =>
-        _$_AndroidPlatformConstraintsStorageV3(
+        _$AndroidPlatformConstraintsStorageV3Impl(
           minSdkVersion: json['minSdkVersion'] as int?,
           compileSdkVersion: json['compileSdkVersion'] as int?,
           targetSdkVersion: json['targetSdkVersion'] as int?,
         );
 
-Map<String, dynamic> _$$_AndroidPlatformConstraintsStorageV3ToJson(
-        _$_AndroidPlatformConstraintsStorageV3 instance) =>
+Map<String, dynamic> _$$AndroidPlatformConstraintsStorageV3ImplToJson(
+        _$AndroidPlatformConstraintsStorageV3Impl instance) =>
     <String, dynamic>{
       'minSdkVersion': instance.minSdkVersion,
       'compileSdkVersion': instance.compileSdkVersion,

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
@@ -102,12 +102,12 @@ class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
+abstract class _$$TypeAliasDeclarationStorageV3ImplCopyWith<$Res>
     implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
-  factory _$$_TypeAliasDeclarationStorageV3CopyWith(
-          _$_TypeAliasDeclarationStorageV3 value,
-          $Res Function(_$_TypeAliasDeclarationStorageV3) then) =
-      __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>;
+  factory _$$TypeAliasDeclarationStorageV3ImplCopyWith(
+          _$TypeAliasDeclarationStorageV3Impl value,
+          $Res Function(_$TypeAliasDeclarationStorageV3Impl) then) =
+      __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
@@ -120,13 +120,13 @@ abstract class _$$_TypeAliasDeclarationStorageV3CopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
+class __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>
     extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-        _$_TypeAliasDeclarationStorageV3>
-    implements _$$_TypeAliasDeclarationStorageV3CopyWith<$Res> {
-  __$$_TypeAliasDeclarationStorageV3CopyWithImpl(
-      _$_TypeAliasDeclarationStorageV3 _value,
-      $Res Function(_$_TypeAliasDeclarationStorageV3) _then)
+        _$TypeAliasDeclarationStorageV3Impl>
+    implements _$$TypeAliasDeclarationStorageV3ImplCopyWith<$Res> {
+  __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl(
+      _$TypeAliasDeclarationStorageV3Impl _value,
+      $Res Function(_$TypeAliasDeclarationStorageV3Impl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -139,7 +139,7 @@ class __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$_TypeAliasDeclarationStorageV3(
+    return _then(_$TypeAliasDeclarationStorageV3Impl(
       name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
@@ -170,8 +170,9 @@ class __$$_TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
-  const _$_TypeAliasDeclarationStorageV3(
+class _$TypeAliasDeclarationStorageV3Impl
+    extends _TypeAliasDeclarationStorageV3 {
+  const _$TypeAliasDeclarationStorageV3Impl(
       {required this.name,
       required this.aliasedTypeName,
       required this.isDeprecated,
@@ -181,9 +182,9 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
       : _entryPoints = entryPoints,
         super._();
 
-  factory _$_TypeAliasDeclarationStorageV3.fromJson(
+  factory _$TypeAliasDeclarationStorageV3Impl.fromJson(
           Map<String, dynamic> json) =>
-      _$$_TypeAliasDeclarationStorageV3FromJson(json);
+      _$$TypeAliasDeclarationStorageV3ImplFromJson(json);
 
   @override
   final String name;
@@ -213,7 +214,7 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TypeAliasDeclarationStorageV3 &&
+            other is _$TypeAliasDeclarationStorageV3Impl &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.aliasedTypeName, aliasedTypeName) ||
                 other.aliasedTypeName == aliasedTypeName) &&
@@ -241,13 +242,14 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TypeAliasDeclarationStorageV3CopyWith<_$_TypeAliasDeclarationStorageV3>
-      get copyWith => __$$_TypeAliasDeclarationStorageV3CopyWithImpl<
-          _$_TypeAliasDeclarationStorageV3>(this, _$identity);
+  _$$TypeAliasDeclarationStorageV3ImplCopyWith<
+          _$TypeAliasDeclarationStorageV3Impl>
+      get copyWith => __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<
+          _$TypeAliasDeclarationStorageV3Impl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_TypeAliasDeclarationStorageV3ToJson(
+    return _$$TypeAliasDeclarationStorageV3ImplToJson(
       this,
     );
   }
@@ -256,16 +258,17 @@ class _$_TypeAliasDeclarationStorageV3 extends _TypeAliasDeclarationStorageV3 {
 abstract class _TypeAliasDeclarationStorageV3
     extends TypeAliasDeclarationStorageV3 {
   const factory _TypeAliasDeclarationStorageV3(
-      {required final String name,
-      required final String aliasedTypeName,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final Set<String> entryPoints,
-      required final String relativePath}) = _$_TypeAliasDeclarationStorageV3;
+          {required final String name,
+          required final String aliasedTypeName,
+          required final bool isDeprecated,
+          required final bool isExperimental,
+          required final Set<String> entryPoints,
+          required final String relativePath}) =
+      _$TypeAliasDeclarationStorageV3Impl;
   const _TypeAliasDeclarationStorageV3._() : super._();
 
   factory _TypeAliasDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$_TypeAliasDeclarationStorageV3.fromJson;
+      _$TypeAliasDeclarationStorageV3Impl.fromJson;
 
   @override
   String get name;
@@ -281,6 +284,7 @@ abstract class _TypeAliasDeclarationStorageV3
   String get relativePath;
   @override
   @JsonKey(ignore: true)
-  _$$_TypeAliasDeclarationStorageV3CopyWith<_$_TypeAliasDeclarationStorageV3>
+  _$$TypeAliasDeclarationStorageV3ImplCopyWith<
+          _$TypeAliasDeclarationStorageV3Impl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.g.dart
@@ -8,21 +8,21 @@ part of 'type_alias_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$_TypeAliasDeclarationStorageV3 _$$_TypeAliasDeclarationStorageV3FromJson(
-        Map<String, dynamic> json) =>
-    _$_TypeAliasDeclarationStorageV3(
-      name: json['name'] as String,
-      aliasedTypeName: json['aliasedTypeName'] as String,
-      isDeprecated: json['isDeprecated'] as bool,
-      isExperimental: json['isExperimental'] as bool,
-      entryPoints: (json['entryPoints'] as List<dynamic>)
-          .map((e) => e as String)
-          .toSet(),
-      relativePath: json['relativePath'] as String,
-    );
+_$TypeAliasDeclarationStorageV3Impl
+    _$$TypeAliasDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
+        _$TypeAliasDeclarationStorageV3Impl(
+          name: json['name'] as String,
+          aliasedTypeName: json['aliasedTypeName'] as String,
+          isDeprecated: json['isDeprecated'] as bool,
+          isExperimental: json['isExperimental'] as bool,
+          entryPoints: (json['entryPoints'] as List<dynamic>)
+              .map((e) => e as String)
+              .toSet(),
+          relativePath: json['relativePath'] as String,
+        );
 
-Map<String, dynamic> _$$_TypeAliasDeclarationStorageV3ToJson(
-        _$_TypeAliasDeclarationStorageV3 instance) =>
+Map<String, dynamic> _$$TypeAliasDeclarationStorageV3ImplToJson(
+        _$TypeAliasDeclarationStorageV3Impl instance) =>
     <String, dynamic>{
       'name': instance.name,
       'aliasedTypeName': instance.aliasedTypeName,

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -76,6 +76,45 @@ void main() {
     );
 
     test(
+      'local packages don\'t break own package refs',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp();
+        final tempFilePath = path.join(tempDir.path, 'extract_paths_test.json');
+        final exitCode = await runner.run([
+          'extract',
+          '--input',
+          path.join(
+            'test',
+            'test_packages',
+            'path_references',
+            'cluster_a',
+            'package_a',
+          ),
+          '--output',
+          tempFilePath,
+        ]);
+        expect(exitCode, 0);
+
+        final jsonReportFile = File(tempFilePath);
+        expect(await jsonReportFile.exists(), isTrue);
+
+        final jsonReport = jsonDecode(await jsonReportFile.readAsString());
+        await tempDir.delete(recursive: true);
+
+        // check if the thisIsAMixinField in ClassA was extracted
+        final interfaceDeclarations =
+            jsonReport['packageApi']['interfaceDeclarations'] as List;
+        final classADeclaration =
+            interfaceDeclarations.singleWhere((id) => id['name'] == 'ClassA');
+        final thisIsAMixinFields =
+            (classADeclaration['fieldDeclarations'] as List)
+                .where((fd) => fd['name'] == 'thisIsAMixinField');
+        expect(thisIsAMixinFields.length, 1);
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
       'Can handle pub ref',
       () async {
         final exitCode = await runner.run([

--- a/test/test_packages/path_references/cluster_a/package_a/lib/types/class_a.dart
+++ b/test/test_packages/path_references/cluster_a/package_a/lib/types/class_a.dart
@@ -1,8 +1,9 @@
 import 'package:meta/meta.dart';
 import 'package:package_b/package_b.dart';
+import 'package:package_a/types/mixin_a.dart';
 
 @experimental
-class ClassA {
+class ClassA with MixinA {
   final ClassB classB;
 
   ClassA({required this.classB});

--- a/test/test_packages/path_references/cluster_a/package_a/lib/types/mixin_a.dart
+++ b/test/test_packages/path_references/cluster_a/package_a/lib/types/mixin_a.dart
@@ -1,0 +1,3 @@
+mixin MixinA {
+  int thisIsAMixinField;
+}


### PR DESCRIPTION
## Description
The logic that is adapting relative paths in the package_config.json also adapts the relative path to the main package (../) breaking any imports that use the package ref even inside the package.

This PR fixes that by omitting that directory from the adaption logic

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping