### PR TITLE
Flutter upgrade and Record support

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.13.5",
+  "flutterSdkVersion": "3.16.4",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.16.4
+## Version 0.17.0
 - bump dart SDK requirements to >=3.0.0
 
 ## Version 0.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.16.4
+- adds support for Dart 3 Record types
+- bump dart SDK requirements to >=3.0.0
+
 ## Version 0.16.3
 - adds more diff result reporting options (cli, json, markdown)
 - fixes broken local packages refs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Version 0.16.4
-- adds support for Dart 3 Record types
 - bump dart SDK requirements to >=3.0.0
 
 ## Version 0.16.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.16.4-dev
+version: 0.17.0-dev
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/bmw-tech/dart_apitool
 version: 0.16.4-dev
 
 environment:
-  sdk: ">=2.17.5 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   analyzer: ^6.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,10 +27,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.1
   freezed: ^2.2.0
   json_serializable: ^6.3.1
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.4
 
 executables:

--- a/test/integration_tests/diff/test_package_records_test.dart
+++ b/test/integration_tests/diff/test_package_records_test.dart
@@ -1,0 +1,53 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('test_package_records', () {
+    late PackageApiAnalyzer packageAWithRecord;
+    late PackageApiAnalyzer packageAWithChangedRecord;
+
+    setUpAll(
+      () {
+        packageAWithRecord = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'records',
+          'package_a_with_record',
+        ));
+        packageAWithChangedRecord = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'records',
+          'package_a_with_changed_record',
+        ));
+      },
+    );
+    group('changing the record type structure', () {
+      late PackageApiDiffResult diffResult;
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageAWithRecord.analyze(),
+          newApi: await packageAWithChangedRecord.analyze(),
+        );
+      });
+
+      test('is detected as breaking change', () {
+        expect(
+          diffResult.apiChanges,
+          containsOnce(
+            predicate(
+              (ApiChange change) =>
+                  change.isBreaking &&
+                  change.changeDescription
+                      .contains('({int? someOtherValue, String someValue})') &&
+                  change.affectedDeclaration!.toString().contains('asRecord'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/test/test_packages/records/package_a_with_changed_record/.gitignore
+++ b/test/test_packages/records/package_a_with_changed_record/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/records/package_a_with_changed_record/CHANGELOG.md
+++ b/test/test_packages/records/package_a_with_changed_record/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/records/package_a_with_changed_record/README.md
+++ b/test/test_packages/records/package_a_with_changed_record/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/records/package_a_with_changed_record/analysis_options.yaml
+++ b/test/test_packages/records/package_a_with_changed_record/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/records/package_a_with_changed_record/lib/package_a.dart
+++ b/test/test_packages/records/package_a_with_changed_record/lib/package_a.dart
@@ -1,0 +1,6 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library package_a;
+
+export 'src/class_a.dart';

--- a/test/test_packages/records/package_a_with_changed_record/lib/src/class_a.dart
+++ b/test/test_packages/records/package_a_with_changed_record/lib/src/class_a.dart
@@ -3,5 +3,6 @@ class ClassA {
   final int? someOtherValue;
   const ClassA(this.someValue, this.someOtherValue);
 
-  ({String someValue, int someOtherValue}) get asRecord => (someValue: someValue, someOtherValue: someOtherValue ?? 0);
+  ({String someValue, int someOtherValue}) get asRecord =>
+      (someValue: someValue, someOtherValue: someOtherValue ?? 0);
 }

--- a/test/test_packages/records/package_a_with_changed_record/lib/src/class_a.dart
+++ b/test/test_packages/records/package_a_with_changed_record/lib/src/class_a.dart
@@ -1,0 +1,7 @@
+class ClassA {
+  final String someValue;
+  final int? someOtherValue;
+  const ClassA(this.someValue, this.someOtherValue);
+
+  ({String someValue, int someOtherValue}) get asRecord => (someValue: someValue, someOtherValue: someOtherValue ?? 0);
+}

--- a/test/test_packages/records/package_a_with_changed_record/pubspec.yaml
+++ b/test/test_packages/records/package_a_with_changed_record/pubspec.yaml
@@ -1,0 +1,14 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.1.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/test/test_packages/records/package_a_with_record/.gitignore
+++ b/test/test_packages/records/package_a_with_record/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/records/package_a_with_record/CHANGELOG.md
+++ b/test/test_packages/records/package_a_with_record/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/records/package_a_with_record/README.md
+++ b/test/test_packages/records/package_a_with_record/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/records/package_a_with_record/analysis_options.yaml
+++ b/test/test_packages/records/package_a_with_record/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/records/package_a_with_record/lib/package_a.dart
+++ b/test/test_packages/records/package_a_with_record/lib/package_a.dart
@@ -1,0 +1,6 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library package_a;
+
+export 'src/class_a.dart';

--- a/test/test_packages/records/package_a_with_record/lib/src/class_a.dart
+++ b/test/test_packages/records/package_a_with_record/lib/src/class_a.dart
@@ -3,5 +3,6 @@ class ClassA {
   final int? someOtherValue;
   const ClassA(this.someValue, this.someOtherValue);
 
-  ({String someValue, int? someOtherValue}) get asRecord => (someValue: someValue, someOtherValue: someOtherValue);
+  ({String someValue, int? someOtherValue}) get asRecord =>
+      (someValue: someValue, someOtherValue: someOtherValue);
 }

--- a/test/test_packages/records/package_a_with_record/lib/src/class_a.dart
+++ b/test/test_packages/records/package_a_with_record/lib/src/class_a.dart
@@ -1,0 +1,7 @@
+class ClassA {
+  final String someValue;
+  final int? someOtherValue;
+  const ClassA(this.someValue, this.someOtherValue);
+
+  ({String someValue, int? someOtherValue}) get asRecord => (someValue: someValue, someOtherValue: someOtherValue);
+}

--- a/test/test_packages/records/package_a_with_record/pubspec.yaml
+++ b/test/test_packages/records/package_a_with_record/pubspec.yaml
@@ -1,0 +1,14 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies: 
+  lints: ^2.0.0
+  test: ^1.21.0


### PR DESCRIPTION
## Description
This PR does:
- bump the used Flutter version to 3.16.4
- upgrades dependencies
- sets the minimum Dart SDK to 3.0.0
- adds a Unit test for Record structure change detection

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
