### PR TITLE
Treat dynamic and object equivalent for inflowing usages

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.16.4",
+  "flutterSdkVersion": "3.16.9",
   "flavors": {}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.18.0
 - add missing export to json output for `extract` command
+- fix change compatibility check for `dynamic` and `Object?` parameters
 
 ## Version 0.17.0
 - bump dart SDK requirements to >=3.0.0

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -19,6 +19,9 @@ class TypeIdentifier with _$TypeIdentifier {
   /// returns true if this type identifier contains the nullable flag
   bool get isNullable => typeName.endsWith('?');
 
+  /// returns true if this type identifier is the dynamic type
+  bool get isDynamic => typeName == 'dynamic';
+
   /// returns the name without the nullable flag
   String get nonNullableTypeName => typeName.endsWith('?')
       ? typeName.substring(0, typeName.length - 1)
@@ -177,6 +180,12 @@ class TypeHierarchy {
     TypeIdentifier typeIdentifierToAssign,
     TypeIdentifier targetTypeIdentifier,
   ) {
+    if (targetTypeIdentifier.isDynamic) {
+      return true;
+    }
+    if (targetTypeIdentifier.typeName == 'Object?') {
+      return true;
+    }
     // if we try to assign a nullable type to a non-nullable then we can return early
     if (!targetTypeIdentifier.isNullable && typeIdentifierToAssign.isNullable) {
       return false;

--- a/test/integration_tests/diff/http2_test.dart
+++ b/test/integration_tests/diff/http2_test.dart
@@ -1,0 +1,37 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+
+import '../helper/integration_test_helper.dart';
+
+void main() {
+  group('http2 version diff', () {
+    group('2.3.0 to 2.3.1_wip', () {
+      final packageName = 'http2';
+      final retriever_2_3_0 = PackageApiRetriever(packageName, '2.3.0');
+      final retriever_2_3_1_wip = GitPackageApiRetriever(
+          'https://github.com/dart-lang/http2.git',
+          'aeb506cb0fc78e42a812137cdc40ed307fe8f64c');
+      late PackageApiDiffResult diffResult;
+
+      setUpAll(() async {
+        diffResult = PackageApiDiffer(
+            options: PackageApiDifferOptions(
+          doCheckSdkVersion: false,
+        )).diff(
+          oldApi: await retriever_2_3_0.retrieve(),
+          newApi: await retriever_2_3_1_wip.retrieve(),
+        );
+      });
+
+      test(
+          'no breaking change is detected (even though parameter type changed from dynamic to Object?)',
+          () {
+        expect(
+            diffResult.apiChanges.every((element) => !element.type.isBreaking),
+            isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR fixes the change compatibility handling for `dynamic` and `Object?` so that changing the type of a parameter from `dynamic` to `Object?` is no longer breaking.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

This fixes #172 