### PR TITLE
introduces `override-use-flutter` argument for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage: dart-apitool extract [arguments]
     --[no-]remove-example                Removes examples from the package to analyze.
                                          (defaults to on)
     --[no-]set-exit-on-missing-export    Sets exit code to != 0 if missing exports are detected in the API.
+    --override-use-flutter               Overrides automatic decision whether to use Flutter or Dart.
 ```
 
 ### diff
@@ -91,10 +92,12 @@ Usage: dart-apitool diff [arguments]
                                          [none, allowAdding (default), strict]
     --[no-]remove-example                Removes examples from the package to analyze.
                                          (defaults to on)
-    --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces (yielding less strict version bump requirements)
+    --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces
+                                         (yielding less strict version bump requirements)
     --report-format                      Which output format should be used
                                          [cli (default), markdown, json]
     --report-file-path                   Where to store the report file (no effect on cli option)
+    --override-use-flutter               Overrides automatic decision whether to use Flutter or Dart.
 ```
 
 ## Integration

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -97,8 +97,10 @@ You may want to do this if you want to make sure
     );
     argParser.addFlag(
       _optionNameIgnoreRequiredness,
-      help:
-          'Whether to ignore the required aspect of interfaces (yielding less strict version bump requirements)',
+      help: '''
+Whether to ignore the required aspect of interfaces 
+(yielding less strict version bump requirements)
+''',
       defaultsTo: false,
       negatable: true,
     );
@@ -114,6 +116,7 @@ You may want to do this if you want to make sure
       help: 'Where to store the report file (no effect on cli option)',
       mandatory: false,
     );
+    init(argParser);
   }
 
   @override
@@ -150,18 +153,22 @@ You may want to do this if you want to make sure
         argResults![_optionNameIgnoreRequiredness] as bool;
 
     final preparedOldPackageRef = await prepare(
+      argResults!,
       oldPackageRef,
     );
     final preparedNewPackageRef = await prepare(
+      argResults!,
       newPackageRef,
     );
 
     final oldPackageApi = await analyze(
+      argResults!,
       preparedOldPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,
     );
     final newPackageApi = await analyze(
+      argResults!,
       preparedNewPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,

--- a/lib/src/cli/commands/extract_command.dart
+++ b/lib/src/cli/commands/extract_command.dart
@@ -60,6 +60,7 @@ If not specified the extracted API will be printed to the console.
       defaultsTo: false,
       negatable: true,
     );
+    init(argParser);
   }
 
   @override
@@ -72,9 +73,11 @@ If not specified the extracted API will be printed to the console.
         argResults![_optionNameSetExitCodeOnMissingExport] as bool;
 
     final preparedPackageRef = await prepare(
+      argResults!,
       packageRef,
     );
     final packageApi = await analyze(
+      argResults!,
       preparedPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
       doRemoveExample: doRemoveExample,

--- a/lib/src/tooling/pub_interaction.dart
+++ b/lib/src/tooling/pub_interaction.dart
@@ -111,6 +111,7 @@ abstract class PubInteraction {
   static Future runPubGet(
     String packageDirectory, {
     StdoutSession? stdoutSession,
+    bool? overrideUseFlutterCommand,
   }) async {
     return DartInteraction.runDartOrFlutterCommand(
       packageDirectory,
@@ -119,6 +120,7 @@ abstract class PubInteraction {
         'get',
       ],
       stdoutSession: stdoutSession,
+      overrideUseFlutterCommand: overrideUseFlutterCommand,
     );
   }
 }


### PR DESCRIPTION
## Description
This PR adds a new argument for dart_apitool commands: `override-use-flutter`.
This optional argument allows the user to override the automatic decision whether to use Flutter or Dart.

Without this flag being set dart_apitool tries to determine the tool to use by inspecting the pubspec.yaml of the package.
There are some conditions (e.g. dependencies that need Flutter while the package under investigation only needs Dart) that make it necessary to override this automatic detection.

## Type of Change

- [x] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
