### PR TITLE
changes the default for checking the SDK version and treating it as a breaking change to `off`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - introduces `force-use-flutter` option for all commands to force dart_apitool to use the `flutter` command.
 - extend type usage tracking and fix situations in which types that are used in @visibleForTesting contexts were detected as not exported
 - fix: don't treat adding static elements (methods, fields) or consts to a required interface as breaking
+- fix: changed default for `--check-sdk-version` from `on` to `off as changing the SDK version can not lead to breaking existing consumer code
 
 ## Version 0.18.0
 - add missing export to json output for `extract` command

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Usage: dart-apitool diff [arguments]
                                          This affects the exit code of this program.
                                          [none, fully (default), onlyBreakingChanges]
     --[no-]check-sdk-version             Determines if the SDK version should be checked.
-                                         (defaults to on)
+                                         (defaults to off)
     --[no-]ignore-prerelease             Determines if the pre-release aspect of the new version
                                          shall be ignored when checking versions.
                                          You may want to do this if you want to make sure

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -60,8 +60,9 @@ This affects the exit code of this program.
     );
     argParser.addFlag(
       _optionNameCheckSdkVersion,
-      help: 'Determines if the SDK version should be checked.',
-      defaultsTo: true,
+      help:
+          'Determines if the SDK version should be checked.\n(defaults to off)',
+      defaultsTo: false,
       negatable: true,
     );
     argParser.addFlag(

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -75,12 +75,12 @@ class PackageApiDiffer {
           newApi.androidPlatformConstraints,
           isExperimental: false,
         ),
-        if (options.doCheckSdkVersion)
-          ..._calculateSdkDiff(
-            oldApi,
-            newApi,
-            isExperimental: false,
-          ),
+        ..._calculateSdkDiff(
+          oldApi,
+          newApi,
+          isExperimental: false,
+          doCheckSdkVersion: options.doCheckSdkVersion,
+        ),
         ..._calculatePackageDependenciesDiff(
           oldApi,
           newApi,
@@ -1123,8 +1123,12 @@ class PackageApiDiffer {
     return changes;
   }
 
-  List<ApiChange> _calculateSdkDiff(PackageApi oldApi, PackageApi newApi,
-      {required bool isExperimental}) {
+  List<ApiChange> _calculateSdkDiff(
+    PackageApi oldApi,
+    PackageApi newApi, {
+    required bool isExperimental,
+    required bool doCheckSdkVersion,
+  }) {
     final result = <ApiChange>[];
     if (oldApi.sdkType != newApi.sdkType) {
       result.add(
@@ -1139,19 +1143,21 @@ class PackageApiDiffer {
         ),
       );
     }
-    // lowering the version is no problem => check if new version is higher
-    if (oldApi.minSdkVersion < newApi.minSdkVersion) {
-      result.add(
-        ApiChange(
-          changeCode: ApiChangeCode.csdk02,
-          affectedDeclaration: null,
-          contextTrace: [],
-          type: ApiChangeType.changeBreaking,
-          isExperimental: isExperimental,
-          changeDescription:
-              'Minimum SDK version changed from ${oldApi.minSdkVersion} to ${newApi.minSdkVersion}',
-        ),
-      );
+    if (doCheckSdkVersion) {
+      // lowering the version is no problem => check if new version is higher
+      if (oldApi.minSdkVersion < newApi.minSdkVersion) {
+        result.add(
+          ApiChange(
+            changeCode: ApiChangeCode.csdk02,
+            affectedDeclaration: null,
+            contextTrace: [],
+            type: ApiChangeType.changeBreaking,
+            isExperimental: isExperimental,
+            changeDescription:
+                'Minimum SDK version changed from ${oldApi.minSdkVersion} to ${newApi.minSdkVersion}',
+          ),
+        );
+      }
     }
     return result;
   }

--- a/readme/change_codes.md
+++ b/readme/change_codes.md
@@ -77,7 +77,8 @@ If the flag got removed then this change is non-breaking. Adding an experimental
 
 If the flag got removed then this change is non-breaking. Adding a sealed flag is considered a breaking change.
 
-## Executables are constructors, methods, and functions. They are all treated the same way.
+## Executables
+Executables are constructors, methods, and functions. They are all treated the same way.
 
 ### CE01
 
@@ -102,7 +103,7 @@ If a renaming of a named parameter is detected, then this change is breaking. A 
 
 > Executable parameters are reordered
 
-That's a tricky one. Dart-apitool tries to match the old and the new parameters based on name and type to try to follow the reordering. If a reordering happened with named parameters and dart-apitool is able to match them then we have a non-breaking change. If it has (or dart-apitool things that it has) any effect on the user's code then we have a breaking change.
+That's a tricky one. Dart-apitool tries to match the old and the new parameters based on name and type to try to follow the reordering. If a reordering happened with named parameters and dart-apitool is able to match them then we have a non-breaking change. If it has (or dart-apitool thinks that it has) any effect on the user's code then we have a breaking change.
 
 ### CE05
 


### PR DESCRIPTION
## Description

Changing the SDK version can't break existing consumer code as pub would not consider the new package that has a non-fitting SDK version boundary. 
That way the existing code would continue to use the older version that still has a fitting SDK version. 

A package owner might still consider introducing a major version bump in that case, that's why this option is still there but off by default


## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

Fixes #183 