### PR TITLE
Fix: widening return types is not breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.19.1
+- fixes widening return types not being detected as a breaking change
+
 ## Version 0.19.0
 - introduces `force-use-flutter` option for all commands to force dart_apitool to use the `flutter` command.
 - extend type usage tracking and fix situations in which types that are used in @visibleForTesting contexts were detected as not exported

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -382,17 +382,7 @@ class PackageApiDiffer {
         newExecutable,
         'Return type changed. ${oldExecutable.returnTypeName} -> ${newExecutable.returnTypeName}',
         changes,
-        isCompatibleChange: typeHierarchy.isCompatibleReplacement(
-          oldTypeIdentifier: TypeIdentifier.fromNameAndLibraryPath(
-            typeName: oldExecutable.returnTypeName,
-            libraryPath: oldExecutable.returnTypeFullLibraryName,
-          ),
-          newTypeIdentifier: TypeIdentifier.fromNameAndLibraryPath(
-            typeName: newExecutable.returnTypeName,
-            libraryPath: newExecutable.returnTypeFullLibraryName,
-          ),
-          isTypePassedIn: false,
-        ),
+        isCompatibleChange: false,
         changeCode: ApiChangeCode.ce09,
         isExperimental: isExperimental,
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.19.0-dev
+version: 0.19.1-dev
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/integration_tests/diff/test_package_dynamic_handling_test.dart
+++ b/test/integration_tests/diff/test_package_dynamic_handling_test.dart
@@ -87,14 +87,14 @@ void main() {
         );
       });
 
-      test('is no breaking change for function return types', () {
+      test('is a breaking change for function return types', () {
         final functionChange = diffResult.apiChanges
             .where((ac) =>
                 ac.affectedDeclaration?.name.contains('function') ?? false)
             .single;
         expect(
           functionChange.isBreaking,
-          isFalse,
+          isTrue,
         );
       });
 

--- a/test/integration_tests/diff/test_package_widening_types_test.dart
+++ b/test/integration_tests/diff/test_package_widening_types_test.dart
@@ -57,6 +57,13 @@ void main() {
           isFalse,
         );
       });
+
+      test('detects return type change and is breaking', () {
+        final localReturnTypeParamChange = diffResult.apiChanges
+            .where((ac) => ac.affectedDeclaration?.name == 'returnSomeInstance')
+            .single;
+        expect(localReturnTypeParamChange.isBreaking, isTrue);
+      });
     });
     group('narrowing types', () {
       late PackageApiDiffResult diffResult;
@@ -88,6 +95,13 @@ void main() {
           localTypeParamChange.isBreaking,
           isTrue,
         );
+      });
+
+      test('detects return type change and is breaking', () {
+        final localReturnTypeParamChange = diffResult.apiChanges
+            .where((ac) => ac.affectedDeclaration?.name == 'returnSomeInstance')
+            .single;
+        expect(localReturnTypeParamChange.isBreaking, isTrue);
       });
     });
   });

--- a/test/test_packages/widening_types_diff/package_a_with_narrow_types/lib/src/class_a.dart
+++ b/test/test_packages/widening_types_diff/package_a_with_narrow_types/lib/src/class_a.dart
@@ -6,6 +6,10 @@ class ClassA {
   void methodUsingLocalType(SomeSubType localTypeParam) {
     print(param);
   }
+
+  SomeSubType returnSomeInstance() {
+    return SomeSubType();
+  }
 }
 
 class SomeSuperType {}

--- a/test/test_packages/widening_types_diff/package_a_with_wider_types/lib/src/class_a.dart
+++ b/test/test_packages/widening_types_diff/package_a_with_wider_types/lib/src/class_a.dart
@@ -6,6 +6,10 @@ class ClassA {
   void methodUsingLocalType(SomeSuperType localTypeParam) {
     print(param);
   }
+
+  SomeSuperType returnSomeInstance() {
+    return SomeSubType();
+  }
 }
 
 class SomeSuperType {}


### PR DESCRIPTION
## Description
Widening the return type was not treated as breaking but consider this scenario:

~~~dart
// old signature
String someMethod();

// new signature
Object someMethod();

//-- breaks those consumer code situations:
// 1
String someVar = someMethod();
// 2
final someVar = someMethod();
final len = someVar.length;
~~~

So every change in return type needs to be breaking!

Fixes #186

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
