### PR TITLE
Adds CI utils with check for lower bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Analyze project source
         run: dart analyze --fatal-infos --fatal-warnings .
 
+      - name: Check lower bound of dependencies
+        run: dart scripts/ci_util/bin/ci_util.dart check-lower-bound-dependencies
+
   semver:
     needs: [get_last_released_version, get_flutter_version]
     uses: bmw-tech/dart_apitool/.github/workflows/check_version.yml@workflow/v1

--- a/scripts/ci_util/.gitignore
+++ b/scripts/ci_util/.gitignore
@@ -1,0 +1,3 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/

--- a/scripts/ci_util/CHANGELOG.md
+++ b/scripts/ci_util/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/scripts/ci_util/README.md
+++ b/scripts/ci_util/README.md
@@ -1,0 +1,1 @@
+CI Utils for dart_apitool

--- a/scripts/ci_util/analysis_options.yaml
+++ b/scripts/ci_util/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/scripts/ci_util/bin/ci_util.dart
+++ b/scripts/ci_util/bin/ci_util.dart
@@ -1,0 +1,11 @@
+import 'package:args/command_runner.dart';
+import 'package:ci_util/src/check_lower_bound_dependencies_command.dart';
+
+CommandRunner buildCommandRunner() {
+  return CommandRunner('ci_util', 'CI utilities for dart_apitool')..addCommand(CheckLowerBoundDependenciesCommand());
+}
+
+void main(List<String> arguments) async {
+  final runner = buildCommandRunner();
+  await runner.run(arguments);
+}

--- a/scripts/ci_util/lib/src/check_lower_bound_dependencies_command.dart
+++ b/scripts/ci_util/lib/src/check_lower_bound_dependencies_command.dart
@@ -1,0 +1,152 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as path;
+import 'package:pubspec_manager/pubspec_manager.dart';
+
+class CheckLowerBoundDependenciesCommand extends Command {
+  @override
+  String get description =>
+      'checks if the package can compile with only the lower bound constraints of its dependencies.';
+
+  @override
+  String get name => 'check-lower-bound-dependencies';
+
+  @override
+  Future run() async {
+    // copy sources to temporary directory
+    final String apiToolRootPath = _getApiToolRootPath();
+
+    // get all dependencies
+    final pubspec =
+        PubSpec.loadFromPath(path.join(apiToolRootPath, 'pubspec.yaml'));
+
+    final testFutures = pubspec.dependencies.list
+        .whereType<DependencyVersioned>()
+        .map((d) async {
+      try {
+        await _testWithFixedDependency((d as Dependency).name);
+      } catch (e) {
+        return (d as Dependency).name + ': ' + e.toString();
+      }
+      return null;
+    });
+    final failedDependencies = (await Future.wait(testFutures))
+        .where((element) => element != null)
+        .toList();
+    if (failedDependencies.isNotEmpty) {
+      throw Exception(
+          'Following dependencies failed when locked to their lower bound: \n${failedDependencies.join('\n-----------\n')}');
+    }
+  }
+
+  Future _testWithFixedDependency(String dependencyName) async {
+    final String apiToolRootPath = _getApiToolRootPath();
+    final tempDir = await Directory.systemTemp.createTemp();
+    try {
+      await _copyPath(apiToolRootPath, tempDir.path);
+      await _fixDependency(
+          path.join(tempDir.path, 'pubspec.yaml'), dependencyName);
+      await _executePubGet(tempDir.path);
+      await _executeBuild(tempDir.path);
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  }
+
+  String _getApiToolRootPath() {
+    return path.normalize(
+      path.join(
+        path.dirname(path.absolute(Platform.script.path)),
+        '..',
+        '..',
+        '..',
+      ),
+    );
+  }
+
+  Future _executePubGet(String path) async {
+    await _executeDart(path, ['pub', 'get']);
+  }
+
+  Future _executeBuild(String path) async {
+    await _executeDart(path, ['compile', 'exe', 'bin/main.dart']);
+  }
+
+  Future _executeDart(String path, List<String> arguments) async {
+    // check if we are in a fvm environment
+    final fvmPath = await Process.run('which', ['fvm']);
+    String executable = 'fvm';
+    List<String> additionalArguments = ['dart'];
+    if (fvmPath.exitCode != 0) {
+      print('fvm not found, using default dart.');
+      executable = 'dart';
+      additionalArguments = [];
+    }
+    final result = await Process.run(
+      executable,
+      [...additionalArguments, ...arguments],
+      workingDirectory: path,
+    );
+    print(result.stdout);
+    print(result.stderr);
+    if (result.exitCode != 0) {
+      throw Exception('Error executing dart: ${result.stderr}');
+    }
+  }
+
+  Future _fixDependency(String pubspecPath, String dependencyName) async {
+    // load pubspec yaml
+    final pubspec = PubSpec.loadFromPath(pubspecPath);
+    // adapt dependency
+    bool adaptedOne = false;
+    for (final dependency in pubspec.dependencies.list) {
+      if (dependency.name == dependencyName &&
+          dependency is DependencyVersioned) {
+        final castedDependency = dependency as DependencyVersioned;
+        castedDependency.versionConstraint =
+            castedDependency.versionConstraint.replaceFirst('^', '');
+        adaptedOne = true;
+      }
+    }
+    if (!adaptedOne) {
+      throw Exception('Dependency $dependencyName not found in pubspec.yaml.');
+    }
+    // write pubspec yaml
+    pubspec.saveTo(pubspecPath);
+  }
+
+  Future<void> _copyPath(String from, String to) async {
+    if (_doNothing(from, to)) {
+      return;
+    }
+    if (await Directory(to).exists()) {
+      await Directory(to).delete();
+    }
+    await Directory(to).create(recursive: true);
+    await for (final file in Directory(from).list(recursive: true)) {
+      // ignore .git directory and its content
+      if (path.split(file.path).contains('.git')) {
+        continue;
+      }
+      final copyTo = path.join(to, path.relative(file.path, from: from));
+      if (file is Directory) {
+        await Directory(copyTo).create(recursive: true);
+      } else if (file is File) {
+        await File(file.path).copy(copyTo);
+      } else if (file is Link) {
+        await Link(copyTo).create(await file.target(), recursive: true);
+      }
+    }
+  }
+
+  bool _doNothing(String from, String to) {
+    if (path.canonicalize(from) == path.canonicalize(to)) {
+      return true;
+    }
+    if (path.isWithin(from, to)) {
+      throw ArgumentError('Cannot copy from $from to $to');
+    }
+    return false;
+  }
+}

--- a/scripts/ci_util/pubspec.yaml
+++ b/scripts/ci_util/pubspec.yaml
@@ -1,0 +1,17 @@
+name: ci_util
+description: A sample command-line application with basic argument parsing.
+version: 0.0.1
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: ^3.3.3
+
+# Add regular dependencies here.
+dependencies:
+  args: ^2.4.2
+  path: ^1.9.0
+  pubspec_manager: ^1.0.0
+
+dev_dependencies:
+  lints: ^3.0.0
+  test: ^1.24.0


### PR DESCRIPTION
## Description
We had issues recently that the promises in our pubspec.yaml ("works with analyzer package ^6.2.0") was wrong.
To detect that we want to have a CI step that tries all the lower bounds of our dependencies.

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
