### PR TITLE
Check if the "lib" directory exists before iterating its sub-tree

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.22.2",
+  "flutter": "3.24.3",
   "flavors": {}
 }

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -384,6 +384,9 @@ class PackageApiAnalyzer {
 
   Iterable<_FileToAnalyzeEntry> _findPublicFilesInProject(
       String normalizedAbsolutePath) {
+    if (!Directory(normalizedAbsolutePath).existsSync()) {
+      return [];
+    }
     final srcPath = path.join(normalizedAbsolutePath, 'src');
     return Directory(normalizedAbsolutePath)
         // if we want to consider all files that are not in the src folder as potential entry points


### PR DESCRIPTION
## Description
Adds a check if the "lib" folder of a package exists before iterating through the sub-tree.
Also bumps the Flutter version to 3.24.3

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

Fixes #195 