### PR TITLE
improve ci utils and fix analyzer lower bound

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Codeowners
-*  @devmil @adamgic @fwagner @fabiomcarneiro @klink182
+*  @devmil @adamgic @fwagner @fabiomcarneiro @klink182 @marafelismino

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.5.0
+  analyzer: ^6.7.0
   args: ^2.3.1
   collection: ^1.17.0
   colorize: ^3.0.0

--- a/scripts/ci_util/pubspec.yaml
+++ b/scripts/ci_util/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   args: ^2.4.2
   path: ^1.9.0
+  pool: ^1.5.1
   pubspec_manager: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description
The last two PRs had a conflict in setting the Flutter version and introducing the lower bounds check.

This PR fixes the lower bound of the analyzer package dependency and improves the ci_utils (parallel task treatment)

Also: add @marafelismino as code owner

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
