### PR TITLE
fix: remove dependency_overrides from temporary pubspec.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.20.1
+- fix: remove dependency overrides from the pubspec.yaml file of the package to analyze as those might point to relative paths that are not resolvable in the context of the package to analyze
+
 ## Version 0.20.0
 - update analyzer's lower boundary to avoid the 'withNullability' required param (it is required on lower versions)
 

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:dart_apitool/api_tool.dart';
 import 'package:dart_apitool/src/cli/source_item.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_manager/pubspec_manager.dart';
 
@@ -179,15 +180,20 @@ OBSOLETE: Has no effect anymore.
     // remove any dependency overrides from the pubspec.yaml
     final pubspecFile = File(p.join(packagePath, 'pubspec.yaml'));
     if (pubspecFile.existsSync()) {
-      final pubSpec = PubSpec.load(directory: packagePath);
-      // removeAll of dependencyOverrides has an issue in the current version of pubspec_manager
-      // as it doesn't remove the section part of the dependency overrides and therefore are not removed
-      // in the saved version of the pubspec.yaml file
-      // workaround: remove all dependency overrides manually
-      for (final depOverride in pubSpec.dependencyOverrides.list) {
-        pubSpec.dependencyOverrides.remove(depOverride.name);
+      try {
+        final pubSpec = PubSpec.load(directory: packagePath);
+        // removeAll of dependencyOverrides has an issue in the current version of pubspec_manager
+        // as it doesn't remove the section part of the dependency overrides and therefore are not removed
+        // in the saved version of the pubspec.yaml file
+        // workaround: remove all dependency overrides manually
+        for (final depOverride in pubSpec.dependencyOverrides.list) {
+          pubSpec.dependencyOverrides.remove(depOverride.name);
+        }
+        pubSpec.save();
+      } catch (e) {
+        await stdoutSession.writeln(
+            'Error removing dependency overrides from pubspec.yaml: $e');
       }
-      pubSpec.save();
     }
 
     // Check if the package_config.json is already present from the preparation step

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:dart_apitool/api_tool.dart';
 import 'package:dart_apitool/src/cli/source_item.dart';
 import 'package:path/path.dart' as p;
+import 'package:pubspec_manager/pubspec_manager.dart';
 
 import '../package_ref.dart';
 import '../prepared_package_ref.dart';
@@ -173,6 +174,20 @@ OBSOLETE: Has no effect anymore.
     final exampleDirPath = p.join(packagePath, 'example');
     if (doRemoveExample && await Directory(exampleDirPath).exists()) {
       await Directory(exampleDirPath).delete(recursive: true);
+    }
+
+    // remove any dependency overrides from the pubspec.yaml
+    final pubspecFile = File(p.join(packagePath, 'pubspec.yaml'));
+    if (pubspecFile.existsSync()) {
+      final pubSpec = PubSpec.load(directory: packagePath);
+      // removeAll of dependencyOverrides has an issue in the current version of pubspec_manager
+      // as it doesn't remove the section part of the dependency overrides and therefore are not removed
+      // in the saved version of the pubspec.yaml file
+      // workaround: remove all dependency overrides manually
+      for (final depOverride in pubSpec.dependencyOverrides.list) {
+        pubSpec.dependencyOverrides.remove(depOverride.name);
+      }
+      pubSpec.save();
     }
 
     // Check if the package_config.json is already present from the preparation step

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:dart_apitool/api_tool.dart';
 import 'package:dart_apitool/src/cli/source_item.dart';
-import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_manager/pubspec_manager.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   path: ^1.9.0
   plist_parser: ^0.0.9
   pub_semver: ^2.1.4
+  pubspec_manager: ^1.0.0
   pubspec_parse: ^1.2.0
   stack: ^0.2.1
   tuple: ^2.0.0

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -240,5 +240,16 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
+    test('Can handle ffigen dependency overrides correctly', () async {
+      final packageName = 'ffigen';
+      final packageVersion = '16.0.0';
+
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        'pub://$packageName/$packageVersion',
+      ]);
+      expect(exitCode, 0);
+    });
   });
 }


### PR DESCRIPTION
## Description
dart_apitool has issues with packages that contain dependency_overrides in their pubspec.yaml and are pulled from pub.
Background:
Packages from pub get downloaded to the pub cache and get copied into a temporary directory to do local adaptions and preparations.
Some packages, especially ones from a mono repository, contain dependency overrides that point to relative paths. Those paths are not valid if you look at this package in isolation and pub get run on that package copy fails as it is not able to resolve those relative path overrides.
To avoid this situation dart_apitool now removed dependency overrides on that local copy (to use the variant of dependencies that would be used transitively anyways)

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

Fixes #198