### PR TITLE
Fix unary operator bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.20.3
+- fix: unary and binary operators can have the same name and crashed dart_apitool
+
 ## Version 0.20.2
 - feat: adds support for Dart workspaces
 

--- a/lib/src/analyze/exported_files_collector.dart
+++ b/lib/src/analyze/exported_files_collector.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print, deprecated_member_use
 
 import 'dart:collection';
 import 'dart:io';

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -539,7 +539,7 @@ class _InterfaceCollectionResult {
 }
 
 @freezed
-class _FileToAnalyzeEntry with _$FileToAnalyzeEntry {
+sealed class _FileToAnalyzeEntry with _$FileToAnalyzeEntry {
   const factory _FileToAnalyzeEntry({
     required String filePath,
     @Default([]) List<String> shownNames,

--- a/lib/src/analyze/package_api_analyzer.freezed.dart
+++ b/lib/src/analyze/package_api_analyzer.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,86 +10,58 @@ part of 'package_api_analyzer.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$FileToAnalyzeEntry {
-  String get filePath => throw _privateConstructorUsedError;
-  List<String> get shownNames => throw _privateConstructorUsedError;
-  List<String> get hiddenNames => throw _privateConstructorUsedError;
-  Set<String> get exportedBy => throw _privateConstructorUsedError;
+  String get filePath;
+  List<String> get shownNames;
+  List<String> get hiddenNames;
+  Set<String> get exportedBy;
 
   /// Create a copy of _FileToAnalyzeEntry
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$FileToAnalyzeEntryCopyWith<_FileToAnalyzeEntry> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$FileToAnalyzeEntryCopyWith<$Res> {
-  factory _$FileToAnalyzeEntryCopyWith(
-          _FileToAnalyzeEntry value, $Res Function(_FileToAnalyzeEntry) then) =
-      __$FileToAnalyzeEntryCopyWithImpl<$Res, _FileToAnalyzeEntry>;
-  @useResult
-  $Res call(
-      {String filePath,
-      List<String> shownNames,
-      List<String> hiddenNames,
-      Set<String> exportedBy});
-}
-
-/// @nodoc
-class __$FileToAnalyzeEntryCopyWithImpl<$Res, $Val extends _FileToAnalyzeEntry>
-    implements _$FileToAnalyzeEntryCopyWith<$Res> {
-  __$FileToAnalyzeEntryCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of _FileToAnalyzeEntry
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  _$FileToAnalyzeEntryCopyWith<_FileToAnalyzeEntry> get copyWith =>
+      __$FileToAnalyzeEntryCopyWithImpl<_FileToAnalyzeEntry>(
+          this as _FileToAnalyzeEntry, _$identity);
+
   @override
-  $Res call({
-    Object? filePath = null,
-    Object? shownNames = null,
-    Object? hiddenNames = null,
-    Object? exportedBy = null,
-  }) {
-    return _then(_value.copyWith(
-      filePath: null == filePath
-          ? _value.filePath
-          : filePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      shownNames: null == shownNames
-          ? _value.shownNames
-          : shownNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      hiddenNames: null == hiddenNames
-          ? _value.hiddenNames
-          : hiddenNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      exportedBy: null == exportedBy
-          ? _value.exportedBy
-          : exportedBy // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FileToAnalyzeEntry &&
+            (identical(other.filePath, filePath) ||
+                other.filePath == filePath) &&
+            const DeepCollectionEquality()
+                .equals(other.shownNames, shownNames) &&
+            const DeepCollectionEquality()
+                .equals(other.hiddenNames, hiddenNames) &&
+            const DeepCollectionEquality()
+                .equals(other.exportedBy, exportedBy));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      filePath,
+      const DeepCollectionEquality().hash(shownNames),
+      const DeepCollectionEquality().hash(hiddenNames),
+      const DeepCollectionEquality().hash(exportedBy));
+
+  @override
+  String toString() {
+    return '_FileToAnalyzeEntry(filePath: $filePath, shownNames: $shownNames, hiddenNames: $hiddenNames, exportedBy: $exportedBy)';
   }
 }
 
 /// @nodoc
-abstract class _$$_FileToAnalyzeEntryImplCopyWith<$Res>
-    implements _$FileToAnalyzeEntryCopyWith<$Res> {
-  factory _$$_FileToAnalyzeEntryImplCopyWith(_$_FileToAnalyzeEntryImpl value,
-          $Res Function(_$_FileToAnalyzeEntryImpl) then) =
-      __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class _$FileToAnalyzeEntryCopyWith<$Res> {
+  factory _$FileToAnalyzeEntryCopyWith(
+          _FileToAnalyzeEntry value, $Res Function(_FileToAnalyzeEntry) _then) =
+      __$FileToAnalyzeEntryCopyWithImpl;
   @useResult
   $Res call(
       {String filePath,
@@ -98,12 +71,12 @@ abstract class _$$_FileToAnalyzeEntryImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>
-    extends __$FileToAnalyzeEntryCopyWithImpl<$Res, _$_FileToAnalyzeEntryImpl>
-    implements _$$_FileToAnalyzeEntryImplCopyWith<$Res> {
-  __$$_FileToAnalyzeEntryImplCopyWithImpl(_$_FileToAnalyzeEntryImpl _value,
-      $Res Function(_$_FileToAnalyzeEntryImpl) _then)
-      : super(_value, _then);
+class __$FileToAnalyzeEntryCopyWithImpl<$Res>
+    implements _$FileToAnalyzeEntryCopyWith<$Res> {
+  __$FileToAnalyzeEntryCopyWithImpl(this._self, this._then);
+
+  final _FileToAnalyzeEntry _self;
+  final $Res Function(_FileToAnalyzeEntry) _then;
 
   /// Create a copy of _FileToAnalyzeEntry
   /// with the given fields replaced by the non-null parameter values.
@@ -115,21 +88,21 @@ class __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>
     Object? hiddenNames = null,
     Object? exportedBy = null,
   }) {
-    return _then(_$_FileToAnalyzeEntryImpl(
+    return _then(_self.copyWith(
       filePath: null == filePath
-          ? _value.filePath
+          ? _self.filePath
           : filePath // ignore: cast_nullable_to_non_nullable
               as String,
       shownNames: null == shownNames
-          ? _value._shownNames
+          ? _self.shownNames
           : shownNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       hiddenNames: null == hiddenNames
-          ? _value._hiddenNames
+          ? _self.hiddenNames
           : hiddenNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       exportedBy: null == exportedBy
-          ? _value._exportedBy
+          ? _self.exportedBy
           : exportedBy // ignore: cast_nullable_to_non_nullable
               as Set<String>,
     ));
@@ -138,8 +111,8 @@ class __$$_FileToAnalyzeEntryImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_FileToAnalyzeEntryImpl implements __FileToAnalyzeEntry {
-  const _$_FileToAnalyzeEntryImpl(
+class __FileToAnalyzeEntry implements _FileToAnalyzeEntry {
+  const __FileToAnalyzeEntry(
       {required this.filePath,
       final List<String> shownNames = const [],
       final List<String> hiddenNames = const [],
@@ -176,16 +149,20 @@ class _$_FileToAnalyzeEntryImpl implements __FileToAnalyzeEntry {
     return EqualUnmodifiableSetView(_exportedBy);
   }
 
+  /// Create a copy of _FileToAnalyzeEntry
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return '_FileToAnalyzeEntry(filePath: $filePath, shownNames: $shownNames, hiddenNames: $hiddenNames, exportedBy: $exportedBy)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$_FileToAnalyzeEntryCopyWith<__FileToAnalyzeEntry> get copyWith =>
+      __$_FileToAnalyzeEntryCopyWithImpl<__FileToAnalyzeEntry>(
+          this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_FileToAnalyzeEntryImpl &&
+            other is __FileToAnalyzeEntry &&
             (identical(other.filePath, filePath) ||
                 other.filePath == filePath) &&
             const DeepCollectionEquality()
@@ -204,36 +181,64 @@ class _$_FileToAnalyzeEntryImpl implements __FileToAnalyzeEntry {
       const DeepCollectionEquality().hash(_hiddenNames),
       const DeepCollectionEquality().hash(_exportedBy));
 
+  @override
+  String toString() {
+    return '_FileToAnalyzeEntry(filePath: $filePath, shownNames: $shownNames, hiddenNames: $hiddenNames, exportedBy: $exportedBy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$_FileToAnalyzeEntryCopyWith<$Res>
+    implements _$FileToAnalyzeEntryCopyWith<$Res> {
+  factory _$_FileToAnalyzeEntryCopyWith(__FileToAnalyzeEntry value,
+          $Res Function(__FileToAnalyzeEntry) _then) =
+      __$_FileToAnalyzeEntryCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String filePath,
+      List<String> shownNames,
+      List<String> hiddenNames,
+      Set<String> exportedBy});
+}
+
+/// @nodoc
+class __$_FileToAnalyzeEntryCopyWithImpl<$Res>
+    implements _$_FileToAnalyzeEntryCopyWith<$Res> {
+  __$_FileToAnalyzeEntryCopyWithImpl(this._self, this._then);
+
+  final __FileToAnalyzeEntry _self;
+  final $Res Function(__FileToAnalyzeEntry) _then;
+
   /// Create a copy of _FileToAnalyzeEntry
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$_FileToAnalyzeEntryImplCopyWith<_$_FileToAnalyzeEntryImpl> get copyWith =>
-      __$$_FileToAnalyzeEntryImplCopyWithImpl<_$_FileToAnalyzeEntryImpl>(
-          this, _$identity);
+  $Res call({
+    Object? filePath = null,
+    Object? shownNames = null,
+    Object? hiddenNames = null,
+    Object? exportedBy = null,
+  }) {
+    return _then(__FileToAnalyzeEntry(
+      filePath: null == filePath
+          ? _self.filePath
+          : filePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      shownNames: null == shownNames
+          ? _self._shownNames
+          : shownNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      hiddenNames: null == hiddenNames
+          ? _self._hiddenNames
+          : hiddenNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      exportedBy: null == exportedBy
+          ? _self._exportedBy
+          : exportedBy // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+    ));
+  }
 }
 
-abstract class __FileToAnalyzeEntry implements _FileToAnalyzeEntry {
-  const factory __FileToAnalyzeEntry(
-      {required final String filePath,
-      final List<String> shownNames,
-      final List<String> hiddenNames,
-      required final Set<String> exportedBy}) = _$_FileToAnalyzeEntryImpl;
-
-  @override
-  String get filePath;
-  @override
-  List<String> get shownNames;
-  @override
-  List<String> get hiddenNames;
-  @override
-  Set<String> get exportedBy;
-
-  /// Create a copy of _FileToAnalyzeEntry
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$_FileToAnalyzeEntryImplCopyWith<_$_FileToAnalyzeEntryImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -95,6 +95,14 @@ class PackageApiDiffer {
     }
   }
 
+  String _interfaceNameWithoutNamespace(String fullName) {
+    final lastDotIndex = fullName.lastIndexOf('.');
+    if (lastDotIndex == -1) {
+      return fullName;
+    }
+    return fullName.substring(lastDotIndex + 1);
+  }
+
   List<ApiChange> _calculateInterfacesDiff(
     List<InterfaceDeclaration> oldInterfaces,
     List<InterfaceDeclaration> newInterfaces,
@@ -107,7 +115,8 @@ class PackageApiDiffer {
       newInterfaces,
       (oldInterface, newInterface) {
         // if the names are not the same, we already have a mismatch
-        if (oldInterface.name != newInterface.name) {
+        if (_interfaceNameWithoutNamespace(oldInterface.name) !=
+            _interfaceNameWithoutNamespace(newInterface.name)) {
           return false;
         }
 

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -1339,9 +1339,13 @@ class PackageApiDiffer {
       final sameMatches =
           newList.where((newItem) => isSameFun(oldItem, newItem));
       if (sameMatches.isNotEmpty) {
-        // if we encounter more than one element here then our whole algorithm crashes (multiple items treated as equal)
-        // => we use `single` here to make sure that we crash if this happens
-        final matchingNewItem = sameMatches.single;
+        final matchingNewItem = sameMatches.singleOrNull;
+
+        if (matchingNewItem == null) {
+          // If we encounter more than one element here then our whole algorithm crashes (multiple items treated as equal)
+          throw ArgumentError('Multiple new items found with the same '
+              'structure as the old item $oldItem: $sameMatches');
+        }
         remainingOld.remove(oldItem);
         remainingNew.remove(matchingNewItem);
 

--- a/lib/src/model/executable_declaration.dart
+++ b/lib/src/model/executable_declaration.dart
@@ -15,7 +15,7 @@ enum ExecutableType {
 
 /// Represents an executable parameter declaration
 @freezed
-class ExecutableParameterDeclaration
+sealed class ExecutableParameterDeclaration
     with _$ExecutableParameterDeclaration
     implements Declaration {
   const ExecutableParameterDeclaration._();
@@ -54,7 +54,7 @@ class ExecutableParameterDeclaration
 
 /// Represents an executable declaration
 @freezed
-class ExecutableDeclaration
+sealed class ExecutableDeclaration
     with _$ExecutableDeclaration
     implements Declaration {
   const ExecutableDeclaration._();

--- a/lib/src/model/executable_declaration.freezed.dart
+++ b/lib/src/model/executable_declaration.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,133 +10,89 @@ part of 'executable_declaration.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ExecutableParameterDeclaration {
   /// whether the parameter is required
-  bool get isRequired => throw _privateConstructorUsedError;
+  bool get isRequired;
 
   /// whether the parameter is named
-  bool get isNamed => throw _privateConstructorUsedError;
+  bool get isNamed;
 
   /// the name of the parameter
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// whether the parameter is deprecated
-  bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isDeprecated;
 
   /// whether the parameter is experimental
-  bool get isExperimental => throw _privateConstructorUsedError;
+  bool get isExperimental;
 
   /// type name of this parameter
-  String get typeName => throw _privateConstructorUsedError;
+  String get typeName;
 
   /// the type library path
-  String? get typeFullLibraryName => throw _privateConstructorUsedError;
+  String? get typeFullLibraryName;
 
   /// the relative path of the library
-  String get relativePath => throw _privateConstructorUsedError;
+  String get relativePath;
 
   /// Create a copy of ExecutableParameterDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $ExecutableParameterDeclarationCopyWith<ExecutableParameterDeclaration>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ExecutableParameterDeclarationCopyWith<$Res> {
-  factory $ExecutableParameterDeclarationCopyWith(
-          ExecutableParameterDeclaration value,
-          $Res Function(ExecutableParameterDeclaration) then) =
-      _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-          ExecutableParameterDeclaration>;
-  @useResult
-  $Res call(
-      {bool isRequired,
-      bool isNamed,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      String typeName,
-      String? typeFullLibraryName,
-      String relativePath});
-}
-
-/// @nodoc
-class _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-        $Val extends ExecutableParameterDeclaration>
-    implements $ExecutableParameterDeclarationCopyWith<$Res> {
-  _$ExecutableParameterDeclarationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ExecutableParameterDeclaration
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $ExecutableParameterDeclarationCopyWith<ExecutableParameterDeclaration>
+      get copyWith => _$ExecutableParameterDeclarationCopyWithImpl<
+              ExecutableParameterDeclaration>(
+          this as ExecutableParameterDeclaration, _$identity);
+
   @override
-  $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? typeName = null,
-    Object? typeFullLibraryName = freezed,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isNamed: null == isNamed
-          ? _value.isNamed
-          : isNamed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      typeFullLibraryName: freezed == typeFullLibraryName
-          ? _value.typeFullLibraryName
-          : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ExecutableParameterDeclaration &&
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
+            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeFullLibraryName, typeFullLibraryName) ||
+                other.typeFullLibraryName == typeFullLibraryName) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      isRequired,
+      isNamed,
+      name,
+      isDeprecated,
+      isExperimental,
+      typeName,
+      typeFullLibraryName,
+      relativePath);
+
+  @override
+  String toString() {
+    return 'ExecutableParameterDeclaration(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$ExecutableParameterDeclarationImplCopyWith<$Res>
-    implements $ExecutableParameterDeclarationCopyWith<$Res> {
-  factory _$$ExecutableParameterDeclarationImplCopyWith(
-          _$ExecutableParameterDeclarationImpl value,
-          $Res Function(_$ExecutableParameterDeclarationImpl) then) =
-      __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $ExecutableParameterDeclarationCopyWith<$Res> {
+  factory $ExecutableParameterDeclarationCopyWith(
+          ExecutableParameterDeclaration value,
+          $Res Function(ExecutableParameterDeclaration) _then) =
+      _$ExecutableParameterDeclarationCopyWithImpl;
   @useResult
   $Res call(
       {bool isRequired,
@@ -149,14 +106,12 @@ abstract class _$$ExecutableParameterDeclarationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationCopyWithImpl<$Res,
-        _$ExecutableParameterDeclarationImpl>
-    implements _$$ExecutableParameterDeclarationImplCopyWith<$Res> {
-  __$$ExecutableParameterDeclarationImplCopyWithImpl(
-      _$ExecutableParameterDeclarationImpl _value,
-      $Res Function(_$ExecutableParameterDeclarationImpl) _then)
-      : super(_value, _then);
+class _$ExecutableParameterDeclarationCopyWithImpl<$Res>
+    implements $ExecutableParameterDeclarationCopyWith<$Res> {
+  _$ExecutableParameterDeclarationCopyWithImpl(this._self, this._then);
+
+  final ExecutableParameterDeclaration _self;
+  final $Res Function(ExecutableParameterDeclaration) _then;
 
   /// Create a copy of ExecutableParameterDeclaration
   /// with the given fields replaced by the non-null parameter values.
@@ -172,37 +127,37 @@ class __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>
     Object? typeFullLibraryName = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$ExecutableParameterDeclarationImpl(
+    return _then(_self.copyWith(
       isRequired: null == isRequired
-          ? _value.isRequired
+          ? _self.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       isNamed: null == isNamed
-          ? _value.isNamed
+          ? _self.isNamed
           : isNamed // ignore: cast_nullable_to_non_nullable
               as bool,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       typeName: null == typeName
-          ? _value.typeName
+          ? _self.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
       typeFullLibraryName: freezed == typeFullLibraryName
-          ? _value.typeFullLibraryName
+          ? _self.typeFullLibraryName
           : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
               as String?,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -211,9 +166,9 @@ class __$$ExecutableParameterDeclarationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$ExecutableParameterDeclarationImpl
-    extends _ExecutableParameterDeclaration {
-  const _$ExecutableParameterDeclarationImpl(
+class _ExecutableParameterDeclaration extends ExecutableParameterDeclaration
+    implements Declaration {
+  const _ExecutableParameterDeclaration(
       {required this.isRequired,
       required this.isNamed,
       required this.name,
@@ -256,16 +211,20 @@ class _$ExecutableParameterDeclarationImpl
   @override
   final String relativePath;
 
+  /// Create a copy of ExecutableParameterDeclaration
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'ExecutableParameterDeclaration(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, relativePath: $relativePath)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExecutableParameterDeclarationCopyWith<_ExecutableParameterDeclaration>
+      get copyWith => __$ExecutableParameterDeclarationCopyWithImpl<
+          _ExecutableParameterDeclaration>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ExecutableParameterDeclarationImpl &&
+            other is _ExecutableParameterDeclaration &&
             (identical(other.isRequired, isRequired) ||
                 other.isRequired == isRequired) &&
             (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
@@ -294,219 +253,186 @@ class _$ExecutableParameterDeclarationImpl
       typeFullLibraryName,
       relativePath);
 
-  /// Create a copy of ExecutableParameterDeclaration
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$ExecutableParameterDeclarationImplCopyWith<
-          _$ExecutableParameterDeclarationImpl>
-      get copyWith => __$$ExecutableParameterDeclarationImplCopyWithImpl<
-          _$ExecutableParameterDeclarationImpl>(this, _$identity);
+  String toString() {
+    return 'ExecutableParameterDeclaration(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, relativePath: $relativePath)';
+  }
 }
 
-abstract class _ExecutableParameterDeclaration
-    extends ExecutableParameterDeclaration implements Declaration {
-  const factory _ExecutableParameterDeclaration(
-          {required final bool isRequired,
-          required final bool isNamed,
-          required final String name,
-          required final bool isDeprecated,
-          required final bool isExperimental,
-          required final String typeName,
-          required final String? typeFullLibraryName,
-          required final String relativePath}) =
-      _$ExecutableParameterDeclarationImpl;
-  const _ExecutableParameterDeclaration._() : super._();
-
-  /// whether the parameter is required
+/// @nodoc
+abstract mixin class _$ExecutableParameterDeclarationCopyWith<$Res>
+    implements $ExecutableParameterDeclarationCopyWith<$Res> {
+  factory _$ExecutableParameterDeclarationCopyWith(
+          _ExecutableParameterDeclaration value,
+          $Res Function(_ExecutableParameterDeclaration) _then) =
+      __$ExecutableParameterDeclarationCopyWithImpl;
   @override
-  bool get isRequired;
+  @useResult
+  $Res call(
+      {bool isRequired,
+      bool isNamed,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      String typeName,
+      String? typeFullLibraryName,
+      String relativePath});
+}
 
-  /// whether the parameter is named
-  @override
-  bool get isNamed;
+/// @nodoc
+class __$ExecutableParameterDeclarationCopyWithImpl<$Res>
+    implements _$ExecutableParameterDeclarationCopyWith<$Res> {
+  __$ExecutableParameterDeclarationCopyWithImpl(this._self, this._then);
 
-  /// the name of the parameter
-  @override
-  String get name;
-
-  /// whether the parameter is deprecated
-  @override
-  bool get isDeprecated;
-
-  /// whether the parameter is experimental
-  @override
-  bool get isExperimental;
-
-  /// type name of this parameter
-  @override
-  String get typeName;
-
-  /// the type library path
-  @override
-  String? get typeFullLibraryName;
-
-  /// the relative path of the library
-  @override
-  String get relativePath;
+  final _ExecutableParameterDeclaration _self;
+  final $Res Function(_ExecutableParameterDeclaration) _then;
 
   /// Create a copy of ExecutableParameterDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ExecutableParameterDeclarationImplCopyWith<
-          _$ExecutableParameterDeclarationImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? typeName = null,
+    Object? typeFullLibraryName = freezed,
+    Object? relativePath = null,
+  }) {
+    return _then(_ExecutableParameterDeclaration(
+      isRequired: null == isRequired
+          ? _self.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isNamed: null == isNamed
+          ? _self.isNamed
+          : isNamed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeFullLibraryName: freezed == typeFullLibraryName
+          ? _self.typeFullLibraryName
+          : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
 /// @nodoc
 mixin _$ExecutableDeclaration {
   /// name of the return type
-  String get returnTypeName =>
-      throw _privateConstructorUsedError; // full library name of the return type
-  String? get returnTypeFullLibraryName => throw _privateConstructorUsedError;
+  String get returnTypeName; // full library name of the return type
+  String? get returnTypeFullLibraryName;
 
   /// name of the executable
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// whether the executable is deprecated
-  bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isDeprecated;
 
   /// whether the executable is experimental
-  bool get isExperimental => throw _privateConstructorUsedError;
+  bool get isExperimental;
 
   /// list of the executables parameters ([ExecutableOParameterDeclaration]s)
-  List<ExecutableParameterDeclaration> get parameters =>
-      throw _privateConstructorUsedError;
+  List<ExecutableParameterDeclaration> get parameters;
 
   /// type parameter names of this executable
-  List<String> get typeParameterNames => throw _privateConstructorUsedError;
+  List<String> get typeParameterNames;
 
   /// type of the executable
-  ExecutableType get type => throw _privateConstructorUsedError;
+  ExecutableType get type;
 
   /// whether the executable is a static method
-  bool get isStatic => throw _privateConstructorUsedError;
+  bool get isStatic;
 
   /// entry points for this executable
-  Set<String>? get entryPoints => throw _privateConstructorUsedError;
+  Set<String>? get entryPoints;
 
   /// the relative path of the library
-  String get relativePath => throw _privateConstructorUsedError;
+  String get relativePath;
 
   /// Create a copy of ExecutableDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $ExecutableDeclarationCopyWith<ExecutableDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ExecutableDeclarationCopyWith<$Res> {
-  factory $ExecutableDeclarationCopyWith(ExecutableDeclaration value,
-          $Res Function(ExecutableDeclaration) then) =
-      _$ExecutableDeclarationCopyWithImpl<$Res, ExecutableDeclaration>;
-  @useResult
-  $Res call(
-      {String returnTypeName,
-      String? returnTypeFullLibraryName,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      List<ExecutableParameterDeclaration> parameters,
-      List<String> typeParameterNames,
-      ExecutableType type,
-      bool isStatic,
-      Set<String>? entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$ExecutableDeclarationCopyWithImpl<$Res,
-        $Val extends ExecutableDeclaration>
-    implements $ExecutableDeclarationCopyWith<$Res> {
-  _$ExecutableDeclarationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ExecutableDeclaration
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $ExecutableDeclarationCopyWith<ExecutableDeclaration> get copyWith =>
+      _$ExecutableDeclarationCopyWithImpl<ExecutableDeclaration>(
+          this as ExecutableDeclaration, _$identity);
+
   @override
-  $Res call({
-    Object? returnTypeName = null,
-    Object? returnTypeFullLibraryName = freezed,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
-    Object? entryPoints = freezed,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      returnTypeName: null == returnTypeName
-          ? _value.returnTypeName
-          : returnTypeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      returnTypeFullLibraryName: freezed == returnTypeFullLibraryName
-          ? _value.returnTypeFullLibraryName
-          : returnTypeFullLibraryName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      parameters: null == parameters
-          ? _value.parameters
-          : parameters // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableParameterDeclaration>,
-      typeParameterNames: null == typeParameterNames
-          ? _value.typeParameterNames
-          : typeParameterNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as ExecutableType,
-      isStatic: null == isStatic
-          ? _value.isStatic
-          : isStatic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: freezed == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>?,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ExecutableDeclaration &&
+            (identical(other.returnTypeName, returnTypeName) ||
+                other.returnTypeName == returnTypeName) &&
+            (identical(other.returnTypeFullLibraryName,
+                    returnTypeFullLibraryName) ||
+                other.returnTypeFullLibraryName == returnTypeFullLibraryName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            const DeepCollectionEquality()
+                .equals(other.parameters, parameters) &&
+            const DeepCollectionEquality()
+                .equals(other.typeParameterNames, typeParameterNames) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      returnTypeName,
+      returnTypeFullLibraryName,
+      name,
+      isDeprecated,
+      isExperimental,
+      const DeepCollectionEquality().hash(parameters),
+      const DeepCollectionEquality().hash(typeParameterNames),
+      type,
+      isStatic,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'ExecutableDeclaration(returnTypeName: $returnTypeName, returnTypeFullLibraryName: $returnTypeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$ExecutableDeclarationImplCopyWith<$Res>
-    implements $ExecutableDeclarationCopyWith<$Res> {
-  factory _$$ExecutableDeclarationImplCopyWith(
-          _$ExecutableDeclarationImpl value,
-          $Res Function(_$ExecutableDeclarationImpl) then) =
-      __$$ExecutableDeclarationImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $ExecutableDeclarationCopyWith<$Res> {
+  factory $ExecutableDeclarationCopyWith(ExecutableDeclaration value,
+          $Res Function(ExecutableDeclaration) _then) =
+      _$ExecutableDeclarationCopyWithImpl;
   @useResult
   $Res call(
       {String returnTypeName,
@@ -523,13 +449,12 @@ abstract class _$$ExecutableDeclarationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$ExecutableDeclarationImplCopyWithImpl<$Res>
-    extends _$ExecutableDeclarationCopyWithImpl<$Res,
-        _$ExecutableDeclarationImpl>
-    implements _$$ExecutableDeclarationImplCopyWith<$Res> {
-  __$$ExecutableDeclarationImplCopyWithImpl(_$ExecutableDeclarationImpl _value,
-      $Res Function(_$ExecutableDeclarationImpl) _then)
-      : super(_value, _then);
+class _$ExecutableDeclarationCopyWithImpl<$Res>
+    implements $ExecutableDeclarationCopyWith<$Res> {
+  _$ExecutableDeclarationCopyWithImpl(this._self, this._then);
+
+  final ExecutableDeclaration _self;
+  final $Res Function(ExecutableDeclaration) _then;
 
   /// Create a copy of ExecutableDeclaration
   /// with the given fields replaced by the non-null parameter values.
@@ -548,49 +473,49 @@ class __$$ExecutableDeclarationImplCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$ExecutableDeclarationImpl(
+    return _then(_self.copyWith(
       returnTypeName: null == returnTypeName
-          ? _value.returnTypeName
+          ? _self.returnTypeName
           : returnTypeName // ignore: cast_nullable_to_non_nullable
               as String,
       returnTypeFullLibraryName: freezed == returnTypeFullLibraryName
-          ? _value.returnTypeFullLibraryName
+          ? _self.returnTypeFullLibraryName
           : returnTypeFullLibraryName // ignore: cast_nullable_to_non_nullable
               as String?,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       parameters: null == parameters
-          ? _value._parameters
+          ? _self.parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<ExecutableParameterDeclaration>,
       typeParameterNames: null == typeParameterNames
-          ? _value._typeParameterNames
+          ? _self.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       type: null == type
-          ? _value.type
+          ? _self.type
           : type // ignore: cast_nullable_to_non_nullable
               as ExecutableType,
       isStatic: null == isStatic
-          ? _value.isStatic
+          ? _self.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
       entryPoints: freezed == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -599,8 +524,8 @@ class __$$ExecutableDeclarationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$ExecutableDeclarationImpl extends _ExecutableDeclaration {
-  const _$ExecutableDeclarationImpl(
+class _ExecutableDeclaration extends ExecutableDeclaration {
+  const _ExecutableDeclaration(
       {required this.returnTypeName,
       required this.returnTypeFullLibraryName,
       required this.name,
@@ -684,16 +609,20 @@ class _$ExecutableDeclarationImpl extends _ExecutableDeclaration {
   @override
   final String relativePath;
 
+  /// Create a copy of ExecutableDeclaration
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'ExecutableDeclaration(returnTypeName: $returnTypeName, returnTypeFullLibraryName: $returnTypeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExecutableDeclarationCopyWith<_ExecutableDeclaration> get copyWith =>
+      __$ExecutableDeclarationCopyWithImpl<_ExecutableDeclaration>(
+          this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ExecutableDeclarationImpl &&
+            other is _ExecutableDeclaration &&
             (identical(other.returnTypeName, returnTypeName) ||
                 other.returnTypeName == returnTypeName) &&
             (identical(other.returnTypeFullLibraryName,
@@ -732,77 +661,106 @@ class _$ExecutableDeclarationImpl extends _ExecutableDeclaration {
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
+  @override
+  String toString() {
+    return 'ExecutableDeclaration(returnTypeName: $returnTypeName, returnTypeFullLibraryName: $returnTypeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ExecutableDeclarationCopyWith<$Res>
+    implements $ExecutableDeclarationCopyWith<$Res> {
+  factory _$ExecutableDeclarationCopyWith(_ExecutableDeclaration value,
+          $Res Function(_ExecutableDeclaration) _then) =
+      __$ExecutableDeclarationCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String returnTypeName,
+      String? returnTypeFullLibraryName,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      List<ExecutableParameterDeclaration> parameters,
+      List<String> typeParameterNames,
+      ExecutableType type,
+      bool isStatic,
+      Set<String>? entryPoints,
+      String relativePath});
+}
+
+/// @nodoc
+class __$ExecutableDeclarationCopyWithImpl<$Res>
+    implements _$ExecutableDeclarationCopyWith<$Res> {
+  __$ExecutableDeclarationCopyWithImpl(this._self, this._then);
+
+  final _ExecutableDeclaration _self;
+  final $Res Function(_ExecutableDeclaration) _then;
+
   /// Create a copy of ExecutableDeclaration
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$ExecutableDeclarationImplCopyWith<_$ExecutableDeclarationImpl>
-      get copyWith => __$$ExecutableDeclarationImplCopyWithImpl<
-          _$ExecutableDeclarationImpl>(this, _$identity);
+  $Res call({
+    Object? returnTypeName = null,
+    Object? returnTypeFullLibraryName = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
+    Object? entryPoints = freezed,
+    Object? relativePath = null,
+  }) {
+    return _then(_ExecutableDeclaration(
+      returnTypeName: null == returnTypeName
+          ? _self.returnTypeName
+          : returnTypeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      returnTypeFullLibraryName: freezed == returnTypeFullLibraryName
+          ? _self.returnTypeFullLibraryName
+          : returnTypeFullLibraryName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      parameters: null == parameters
+          ? _self._parameters
+          : parameters // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableParameterDeclaration>,
+      typeParameterNames: null == typeParameterNames
+          ? _self._typeParameterNames
+          : typeParameterNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ExecutableType,
+      isStatic: null == isStatic
+          ? _self.isStatic
+          : isStatic // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: freezed == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>?,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _ExecutableDeclaration extends ExecutableDeclaration {
-  const factory _ExecutableDeclaration(
-      {required final String returnTypeName,
-      required final String? returnTypeFullLibraryName,
-      required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final List<ExecutableParameterDeclaration> parameters,
-      required final List<String> typeParameterNames,
-      required final ExecutableType type,
-      required final bool isStatic,
-      final Set<String>? entryPoints,
-      required final String relativePath}) = _$ExecutableDeclarationImpl;
-  const _ExecutableDeclaration._() : super._();
-
-  /// name of the return type
-  @override
-  String get returnTypeName; // full library name of the return type
-  @override
-  String? get returnTypeFullLibraryName;
-
-  /// name of the executable
-  @override
-  String get name;
-
-  /// whether the executable is deprecated
-  @override
-  bool get isDeprecated;
-
-  /// whether the executable is experimental
-  @override
-  bool get isExperimental;
-
-  /// list of the executables parameters ([ExecutableOParameterDeclaration]s)
-  @override
-  List<ExecutableParameterDeclaration> get parameters;
-
-  /// type parameter names of this executable
-  @override
-  List<String> get typeParameterNames;
-
-  /// type of the executable
-  @override
-  ExecutableType get type;
-
-  /// whether the executable is a static method
-  @override
-  bool get isStatic;
-
-  /// entry points for this executable
-  @override
-  Set<String>? get entryPoints;
-
-  /// the relative path of the library
-  @override
-  String get relativePath;
-
-  /// Create a copy of ExecutableDeclaration
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ExecutableDeclarationImplCopyWith<_$ExecutableDeclarationImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/model/field_declaration.dart
+++ b/lib/src/model/field_declaration.dart
@@ -6,7 +6,7 @@ part 'field_declaration.freezed.dart';
 
 /// represents a found FieldDeclaration
 @freezed
-class FieldDeclaration with _$FieldDeclaration implements Declaration {
+sealed class FieldDeclaration with _$FieldDeclaration implements Declaration {
   const FieldDeclaration._();
 
   /// the signature of this field declaration.

--- a/lib/src/model/field_declaration.freezed.dart
+++ b/lib/src/model/field_declaration.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,156 +10,105 @@ part of 'field_declaration.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$FieldDeclaration {
   /// type of this field
-  String get typeName => throw _privateConstructorUsedError;
+  String get typeName;
 
   /// full library name for the type
-  String? get typeFullLibraryName => throw _privateConstructorUsedError;
+  String? get typeFullLibraryName;
 
   /// name of this field
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// whether this field is deprecated
-  bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isDeprecated;
 
   /// whether this field is static
-  bool get isStatic => throw _privateConstructorUsedError;
+  bool get isStatic;
 
   /// whether this field is a constant
-  bool get isConst => throw _privateConstructorUsedError;
+  bool get isConst;
 
   /// whether this field is experimental
-  bool get isExperimental => throw _privateConstructorUsedError;
+  bool get isExperimental;
 
   /// entry points this field is reachable through
-  Set<String>? get entryPoints => throw _privateConstructorUsedError;
+  Set<String>? get entryPoints;
 
   /// the relative path of the library
-  String get relativePath => throw _privateConstructorUsedError;
+  String get relativePath;
 
   /// whether this field is readable
-  bool get isReadable => throw _privateConstructorUsedError;
+  bool get isReadable;
 
   /// whether this field is writeable
-  bool get isWriteable => throw _privateConstructorUsedError;
+  bool get isWriteable;
 
   /// Create a copy of FieldDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $FieldDeclarationCopyWith<FieldDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $FieldDeclarationCopyWith<$Res> {
-  factory $FieldDeclarationCopyWith(
-          FieldDeclaration value, $Res Function(FieldDeclaration) then) =
-      _$FieldDeclarationCopyWithImpl<$Res, FieldDeclaration>;
-  @useResult
-  $Res call(
-      {String typeName,
-      String? typeFullLibraryName,
-      String name,
-      bool isDeprecated,
-      bool isStatic,
-      bool isConst,
-      bool isExperimental,
-      Set<String>? entryPoints,
-      String relativePath,
-      bool isReadable,
-      bool isWriteable});
-}
-
-/// @nodoc
-class _$FieldDeclarationCopyWithImpl<$Res, $Val extends FieldDeclaration>
-    implements $FieldDeclarationCopyWith<$Res> {
-  _$FieldDeclarationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of FieldDeclaration
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $FieldDeclarationCopyWith<FieldDeclaration> get copyWith =>
+      _$FieldDeclarationCopyWithImpl<FieldDeclaration>(
+          this as FieldDeclaration, _$identity);
+
   @override
-  $Res call({
-    Object? typeName = null,
-    Object? typeFullLibraryName = freezed,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isStatic = null,
-    Object? isConst = null,
-    Object? isExperimental = null,
-    Object? entryPoints = freezed,
-    Object? relativePath = null,
-    Object? isReadable = null,
-    Object? isWriteable = null,
-  }) {
-    return _then(_value.copyWith(
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      typeFullLibraryName: freezed == typeFullLibraryName
-          ? _value.typeFullLibraryName
-          : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isStatic: null == isStatic
-          ? _value.isStatic
-          : isStatic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isConst: null == isConst
-          ? _value.isConst
-          : isConst // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: freezed == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>?,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      isReadable: null == isReadable
-          ? _value.isReadable
-          : isReadable // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isWriteable: null == isWriteable
-          ? _value.isWriteable
-          : isWriteable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is FieldDeclaration &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.typeFullLibraryName, typeFullLibraryName) ||
+                other.typeFullLibraryName == typeFullLibraryName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
+            (identical(other.isConst, isConst) || other.isConst == isConst) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath) &&
+            (identical(other.isReadable, isReadable) ||
+                other.isReadable == isReadable) &&
+            (identical(other.isWriteable, isWriteable) ||
+                other.isWriteable == isWriteable));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeName,
+      typeFullLibraryName,
+      name,
+      isDeprecated,
+      isStatic,
+      isConst,
+      isExperimental,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath,
+      isReadable,
+      isWriteable);
+
+  @override
+  String toString() {
+    return 'FieldDeclaration(typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isStatic: $isStatic, isConst: $isConst, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
   }
 }
 
 /// @nodoc
-abstract class _$$FieldDeclarationImplCopyWith<$Res>
-    implements $FieldDeclarationCopyWith<$Res> {
-  factory _$$FieldDeclarationImplCopyWith(_$FieldDeclarationImpl value,
-          $Res Function(_$FieldDeclarationImpl) then) =
-      __$$FieldDeclarationImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $FieldDeclarationCopyWith<$Res> {
+  factory $FieldDeclarationCopyWith(
+          FieldDeclaration value, $Res Function(FieldDeclaration) _then) =
+      _$FieldDeclarationCopyWithImpl;
   @useResult
   $Res call(
       {String typeName,
@@ -175,12 +125,12 @@ abstract class _$$FieldDeclarationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FieldDeclarationImplCopyWithImpl<$Res>
-    extends _$FieldDeclarationCopyWithImpl<$Res, _$FieldDeclarationImpl>
-    implements _$$FieldDeclarationImplCopyWith<$Res> {
-  __$$FieldDeclarationImplCopyWithImpl(_$FieldDeclarationImpl _value,
-      $Res Function(_$FieldDeclarationImpl) _then)
-      : super(_value, _then);
+class _$FieldDeclarationCopyWithImpl<$Res>
+    implements $FieldDeclarationCopyWith<$Res> {
+  _$FieldDeclarationCopyWithImpl(this._self, this._then);
+
+  final FieldDeclaration _self;
+  final $Res Function(FieldDeclaration) _then;
 
   /// Create a copy of FieldDeclaration
   /// with the given fields replaced by the non-null parameter values.
@@ -199,49 +149,49 @@ class __$$FieldDeclarationImplCopyWithImpl<$Res>
     Object? isReadable = null,
     Object? isWriteable = null,
   }) {
-    return _then(_$FieldDeclarationImpl(
+    return _then(_self.copyWith(
       typeName: null == typeName
-          ? _value.typeName
+          ? _self.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
       typeFullLibraryName: freezed == typeFullLibraryName
-          ? _value.typeFullLibraryName
+          ? _self.typeFullLibraryName
           : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
               as String?,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isStatic: null == isStatic
-          ? _value.isStatic
+          ? _self.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
       isConst: null == isConst
-          ? _value.isConst
+          ? _self.isConst
           : isConst // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       entryPoints: freezed == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
       isReadable: null == isReadable
-          ? _value.isReadable
+          ? _self.isReadable
           : isReadable // ignore: cast_nullable_to_non_nullable
               as bool,
       isWriteable: null == isWriteable
-          ? _value.isWriteable
+          ? _self.isWriteable
           : isWriteable // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
@@ -250,8 +200,8 @@ class __$$FieldDeclarationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$FieldDeclarationImpl extends _FieldDeclaration {
-  const _$FieldDeclarationImpl(
+class _FieldDeclaration extends FieldDeclaration implements Declaration {
+  const _FieldDeclaration(
       {required this.typeName,
       required this.typeFullLibraryName,
       required this.name,
@@ -319,16 +269,19 @@ class _$FieldDeclarationImpl extends _FieldDeclaration {
   @override
   final bool isWriteable;
 
+  /// Create a copy of FieldDeclaration
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'FieldDeclaration(typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isStatic: $isStatic, isConst: $isConst, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$FieldDeclarationCopyWith<_FieldDeclaration> get copyWith =>
+      __$FieldDeclarationCopyWithImpl<_FieldDeclaration>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FieldDeclarationImpl &&
+            other is _FieldDeclaration &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.typeFullLibraryName, typeFullLibraryName) ||
@@ -366,80 +319,106 @@ class _$FieldDeclarationImpl extends _FieldDeclaration {
       isReadable,
       isWriteable);
 
+  @override
+  String toString() {
+    return 'FieldDeclaration(typeName: $typeName, typeFullLibraryName: $typeFullLibraryName, name: $name, isDeprecated: $isDeprecated, isStatic: $isStatic, isConst: $isConst, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$FieldDeclarationCopyWith<$Res>
+    implements $FieldDeclarationCopyWith<$Res> {
+  factory _$FieldDeclarationCopyWith(
+          _FieldDeclaration value, $Res Function(_FieldDeclaration) _then) =
+      __$FieldDeclarationCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String typeName,
+      String? typeFullLibraryName,
+      String name,
+      bool isDeprecated,
+      bool isStatic,
+      bool isConst,
+      bool isExperimental,
+      Set<String>? entryPoints,
+      String relativePath,
+      bool isReadable,
+      bool isWriteable});
+}
+
+/// @nodoc
+class __$FieldDeclarationCopyWithImpl<$Res>
+    implements _$FieldDeclarationCopyWith<$Res> {
+  __$FieldDeclarationCopyWithImpl(this._self, this._then);
+
+  final _FieldDeclaration _self;
+  final $Res Function(_FieldDeclaration) _then;
+
   /// Create a copy of FieldDeclaration
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$FieldDeclarationImplCopyWith<_$FieldDeclarationImpl> get copyWith =>
-      __$$FieldDeclarationImplCopyWithImpl<_$FieldDeclarationImpl>(
-          this, _$identity);
+  $Res call({
+    Object? typeName = null,
+    Object? typeFullLibraryName = freezed,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isStatic = null,
+    Object? isConst = null,
+    Object? isExperimental = null,
+    Object? entryPoints = freezed,
+    Object? relativePath = null,
+    Object? isReadable = null,
+    Object? isWriteable = null,
+  }) {
+    return _then(_FieldDeclaration(
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      typeFullLibraryName: freezed == typeFullLibraryName
+          ? _self.typeFullLibraryName
+          : typeFullLibraryName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isStatic: null == isStatic
+          ? _self.isStatic
+          : isStatic // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isConst: null == isConst
+          ? _self.isConst
+          : isConst // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: freezed == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>?,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      isReadable: null == isReadable
+          ? _self.isReadable
+          : isReadable // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isWriteable: null == isWriteable
+          ? _self.isWriteable
+          : isWriteable // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _FieldDeclaration extends FieldDeclaration
-    implements Declaration {
-  const factory _FieldDeclaration(
-      {required final String typeName,
-      required final String? typeFullLibraryName,
-      required final String name,
-      required final bool isDeprecated,
-      required final bool isStatic,
-      required final bool isConst,
-      required final bool isExperimental,
-      final Set<String>? entryPoints,
-      required final String relativePath,
-      required final bool isReadable,
-      required final bool isWriteable}) = _$FieldDeclarationImpl;
-  const _FieldDeclaration._() : super._();
-
-  /// type of this field
-  @override
-  String get typeName;
-
-  /// full library name for the type
-  @override
-  String? get typeFullLibraryName;
-
-  /// name of this field
-  @override
-  String get name;
-
-  /// whether this field is deprecated
-  @override
-  bool get isDeprecated;
-
-  /// whether this field is static
-  @override
-  bool get isStatic;
-
-  /// whether this field is a constant
-  @override
-  bool get isConst;
-
-  /// whether this field is experimental
-  @override
-  bool get isExperimental;
-
-  /// entry points this field is reachable through
-  @override
-  Set<String>? get entryPoints;
-
-  /// the relative path of the library
-  @override
-  String get relativePath;
-
-  /// whether this field is readable
-  @override
-  bool get isReadable;
-
-  /// whether this field is writeable
-  @override
-  bool get isWriteable;
-
-  /// Create a copy of FieldDeclaration
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$FieldDeclarationImplCopyWith<_$FieldDeclarationImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/model/interface_declaration.dart
+++ b/lib/src/model/interface_declaration.dart
@@ -13,7 +13,9 @@ part 'interface_declaration.freezed.dart';
 
 /// Represents a found interface declaration
 @freezed
-class InterfaceDeclaration with _$InterfaceDeclaration implements Declaration {
+sealed class InterfaceDeclaration
+    with _$InterfaceDeclaration
+    implements Declaration {
   /// the signature of this interface condensed to one String
   /// contains Type arguments as well as base types or implemented interfaces
   String get signature => _computeSignature();

--- a/lib/src/model/interface_declaration.freezed.dart
+++ b/lib/src/model/interface_declaration.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,168 +10,112 @@ part of 'interface_declaration.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$InterfaceDeclaration {
   /// name of this interface
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// whether this interface is deprecated
-  bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isDeprecated;
 
   /// whether this interface is experimental
-  bool get isExperimental => throw _privateConstructorUsedError;
+  bool get isExperimental;
 
   /// determines if this declaration is sealed
-  bool get isSealed => throw _privateConstructorUsedError;
+  bool get isSealed;
 
   /// determines if this declaration is abstract
-  bool get isAbstract => throw _privateConstructorUsedError;
+  bool get isAbstract;
 
   /// usages of this interface
-  Set<TypeUsage> get typeUsages => throw _privateConstructorUsedError;
+  Set<TypeUsage> get typeUsages;
 
   /// list of type parameter names
-  List<String> get typeParameterNames => throw _privateConstructorUsedError;
+  List<String> get typeParameterNames;
 
   /// set of super type names
-  Set<String> get superTypeNames => throw _privateConstructorUsedError;
+  Set<String> get superTypeNames;
 
   /// executables that belong to this interface
-  List<ExecutableDeclaration> get executableDeclarations =>
-      throw _privateConstructorUsedError;
+  List<ExecutableDeclaration> get executableDeclarations;
 
   /// fields that belong to this interface
-  List<FieldDeclaration> get fieldDeclarations =>
-      throw _privateConstructorUsedError;
+  List<FieldDeclaration> get fieldDeclarations;
 
   /// entry points this interface is reachable through
-  Set<String>? get entryPoints => throw _privateConstructorUsedError;
+  Set<String>? get entryPoints;
 
   /// the relative path of the library
-  String get relativePath => throw _privateConstructorUsedError;
+  String get relativePath;
 
   /// Create a copy of InterfaceDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $InterfaceDeclarationCopyWith<InterfaceDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $InterfaceDeclarationCopyWith<$Res> {
-  factory $InterfaceDeclarationCopyWith(InterfaceDeclaration value,
-          $Res Function(InterfaceDeclaration) then) =
-      _$InterfaceDeclarationCopyWithImpl<$Res, InterfaceDeclaration>;
-  @useResult
-  $Res call(
-      {String name,
-      bool isDeprecated,
-      bool isExperimental,
-      bool isSealed,
-      bool isAbstract,
-      Set<TypeUsage> typeUsages,
-      List<String> typeParameterNames,
-      Set<String> superTypeNames,
-      List<ExecutableDeclaration> executableDeclarations,
-      List<FieldDeclaration> fieldDeclarations,
-      Set<String>? entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$InterfaceDeclarationCopyWithImpl<$Res,
-        $Val extends InterfaceDeclaration>
-    implements $InterfaceDeclarationCopyWith<$Res> {
-  _$InterfaceDeclarationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of InterfaceDeclaration
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $InterfaceDeclarationCopyWith<InterfaceDeclaration> get copyWith =>
+      _$InterfaceDeclarationCopyWithImpl<InterfaceDeclaration>(
+          this as InterfaceDeclaration, _$identity);
+
   @override
-  $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? isSealed = null,
-    Object? isAbstract = null,
-    Object? typeUsages = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? entryPoints = freezed,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isSealed: null == isSealed
-          ? _value.isSealed
-          : isSealed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isAbstract: null == isAbstract
-          ? _value.isAbstract
-          : isAbstract // ignore: cast_nullable_to_non_nullable
-              as bool,
-      typeUsages: null == typeUsages
-          ? _value.typeUsages
-          : typeUsages // ignore: cast_nullable_to_non_nullable
-              as Set<TypeUsage>,
-      typeParameterNames: null == typeParameterNames
-          ? _value.typeParameterNames
-          : typeParameterNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      superTypeNames: null == superTypeNames
-          ? _value.superTypeNames
-          : superTypeNames // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-      executableDeclarations: null == executableDeclarations
-          ? _value.executableDeclarations
-          : executableDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
-          ? _value.fieldDeclarations
-          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<FieldDeclaration>,
-      entryPoints: freezed == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>?,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InterfaceDeclaration &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            (identical(other.isSealed, isSealed) ||
+                other.isSealed == isSealed) &&
+            (identical(other.isAbstract, isAbstract) ||
+                other.isAbstract == isAbstract) &&
+            const DeepCollectionEquality()
+                .equals(other.typeUsages, typeUsages) &&
+            const DeepCollectionEquality()
+                .equals(other.typeParameterNames, typeParameterNames) &&
+            const DeepCollectionEquality()
+                .equals(other.superTypeNames, superTypeNames) &&
+            const DeepCollectionEquality()
+                .equals(other.executableDeclarations, executableDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.fieldDeclarations, fieldDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      isDeprecated,
+      isExperimental,
+      isSealed,
+      isAbstract,
+      const DeepCollectionEquality().hash(typeUsages),
+      const DeepCollectionEquality().hash(typeParameterNames),
+      const DeepCollectionEquality().hash(superTypeNames),
+      const DeepCollectionEquality().hash(executableDeclarations),
+      const DeepCollectionEquality().hash(fieldDeclarations),
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isAbstract: $isAbstract, typeUsages: $typeUsages, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$InterfaceDeclarationImplCopyWith<$Res>
-    implements $InterfaceDeclarationCopyWith<$Res> {
-  factory _$$InterfaceDeclarationImplCopyWith(_$InterfaceDeclarationImpl value,
-          $Res Function(_$InterfaceDeclarationImpl) then) =
-      __$$InterfaceDeclarationImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $InterfaceDeclarationCopyWith<$Res> {
+  factory $InterfaceDeclarationCopyWith(InterfaceDeclaration value,
+          $Res Function(InterfaceDeclaration) _then) =
+      _$InterfaceDeclarationCopyWithImpl;
   @useResult
   $Res call(
       {String name,
@@ -188,12 +133,12 @@ abstract class _$$InterfaceDeclarationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$InterfaceDeclarationImplCopyWithImpl<$Res>
-    extends _$InterfaceDeclarationCopyWithImpl<$Res, _$InterfaceDeclarationImpl>
-    implements _$$InterfaceDeclarationImplCopyWith<$Res> {
-  __$$InterfaceDeclarationImplCopyWithImpl(_$InterfaceDeclarationImpl _value,
-      $Res Function(_$InterfaceDeclarationImpl) _then)
-      : super(_value, _then);
+class _$InterfaceDeclarationCopyWithImpl<$Res>
+    implements $InterfaceDeclarationCopyWith<$Res> {
+  _$InterfaceDeclarationCopyWithImpl(this._self, this._then);
+
+  final InterfaceDeclaration _self;
+  final $Res Function(InterfaceDeclaration) _then;
 
   /// Create a copy of InterfaceDeclaration
   /// with the given fields replaced by the non-null parameter values.
@@ -213,53 +158,53 @@ class __$$InterfaceDeclarationImplCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$InterfaceDeclarationImpl(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       isSealed: null == isSealed
-          ? _value.isSealed
+          ? _self.isSealed
           : isSealed // ignore: cast_nullable_to_non_nullable
               as bool,
       isAbstract: null == isAbstract
-          ? _value.isAbstract
+          ? _self.isAbstract
           : isAbstract // ignore: cast_nullable_to_non_nullable
               as bool,
       typeUsages: null == typeUsages
-          ? _value._typeUsages
+          ? _self.typeUsages
           : typeUsages // ignore: cast_nullable_to_non_nullable
               as Set<TypeUsage>,
       typeParameterNames: null == typeParameterNames
-          ? _value._typeParameterNames
+          ? _self.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       superTypeNames: null == superTypeNames
-          ? _value._superTypeNames
+          ? _self.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as Set<String>,
       executableDeclarations: null == executableDeclarations
-          ? _value._executableDeclarations
+          ? _self.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
       fieldDeclarations: null == fieldDeclarations
-          ? _value._fieldDeclarations
+          ? _self.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
       entryPoints: freezed == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -268,8 +213,9 @@ class __$$InterfaceDeclarationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$InterfaceDeclarationImpl extends _InterfaceDeclaration {
-  const _$InterfaceDeclarationImpl(
+class _InterfaceDeclaration extends InterfaceDeclaration
+    implements Declaration {
+  const _InterfaceDeclaration(
       {required this.name,
       required this.isDeprecated,
       required this.isExperimental,
@@ -385,16 +331,20 @@ class _$InterfaceDeclarationImpl extends _InterfaceDeclaration {
   @override
   final String relativePath;
 
+  /// Create a copy of InterfaceDeclaration
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isAbstract: $isAbstract, typeUsages: $typeUsages, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InterfaceDeclarationCopyWith<_InterfaceDeclaration> get copyWith =>
+      __$InterfaceDeclarationCopyWithImpl<_InterfaceDeclaration>(
+          this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$InterfaceDeclarationImpl &&
+            other is _InterfaceDeclaration &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
@@ -436,86 +386,112 @@ class _$InterfaceDeclarationImpl extends _InterfaceDeclaration {
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
+  @override
+  String toString() {
+    return 'InterfaceDeclaration(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isAbstract: $isAbstract, typeUsages: $typeUsages, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InterfaceDeclarationCopyWith<$Res>
+    implements $InterfaceDeclarationCopyWith<$Res> {
+  factory _$InterfaceDeclarationCopyWith(_InterfaceDeclaration value,
+          $Res Function(_InterfaceDeclaration) _then) =
+      __$InterfaceDeclarationCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      bool isDeprecated,
+      bool isExperimental,
+      bool isSealed,
+      bool isAbstract,
+      Set<TypeUsage> typeUsages,
+      List<String> typeParameterNames,
+      Set<String> superTypeNames,
+      List<ExecutableDeclaration> executableDeclarations,
+      List<FieldDeclaration> fieldDeclarations,
+      Set<String>? entryPoints,
+      String relativePath});
+}
+
+/// @nodoc
+class __$InterfaceDeclarationCopyWithImpl<$Res>
+    implements _$InterfaceDeclarationCopyWith<$Res> {
+  __$InterfaceDeclarationCopyWithImpl(this._self, this._then);
+
+  final _InterfaceDeclaration _self;
+  final $Res Function(_InterfaceDeclaration) _then;
+
   /// Create a copy of InterfaceDeclaration
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$InterfaceDeclarationImplCopyWith<_$InterfaceDeclarationImpl>
-      get copyWith =>
-          __$$InterfaceDeclarationImplCopyWithImpl<_$InterfaceDeclarationImpl>(
-              this, _$identity);
+  $Res call({
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? isSealed = null,
+    Object? isAbstract = null,
+    Object? typeUsages = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = freezed,
+    Object? relativePath = null,
+  }) {
+    return _then(_InterfaceDeclaration(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSealed: null == isSealed
+          ? _self.isSealed
+          : isSealed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isAbstract: null == isAbstract
+          ? _self.isAbstract
+          : isAbstract // ignore: cast_nullable_to_non_nullable
+              as bool,
+      typeUsages: null == typeUsages
+          ? _self._typeUsages
+          : typeUsages // ignore: cast_nullable_to_non_nullable
+              as Set<TypeUsage>,
+      typeParameterNames: null == typeParameterNames
+          ? _self._typeParameterNames
+          : typeParameterNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      superTypeNames: null == superTypeNames
+          ? _self._superTypeNames
+          : superTypeNames // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      executableDeclarations: null == executableDeclarations
+          ? _self._executableDeclarations
+          : executableDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableDeclaration>,
+      fieldDeclarations: null == fieldDeclarations
+          ? _self._fieldDeclarations
+          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<FieldDeclaration>,
+      entryPoints: freezed == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>?,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _InterfaceDeclaration extends InterfaceDeclaration
-    implements Declaration {
-  const factory _InterfaceDeclaration(
-      {required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final bool isSealed,
-      required final bool isAbstract,
-      required final Set<TypeUsage> typeUsages,
-      required final List<String> typeParameterNames,
-      required final Set<String> superTypeNames,
-      required final List<ExecutableDeclaration> executableDeclarations,
-      required final List<FieldDeclaration> fieldDeclarations,
-      final Set<String>? entryPoints,
-      required final String relativePath}) = _$InterfaceDeclarationImpl;
-  const _InterfaceDeclaration._() : super._();
-
-  /// name of this interface
-  @override
-  String get name;
-
-  /// whether this interface is deprecated
-  @override
-  bool get isDeprecated;
-
-  /// whether this interface is experimental
-  @override
-  bool get isExperimental;
-
-  /// determines if this declaration is sealed
-  @override
-  bool get isSealed;
-
-  /// determines if this declaration is abstract
-  @override
-  bool get isAbstract;
-
-  /// usages of this interface
-  @override
-  Set<TypeUsage> get typeUsages;
-
-  /// list of type parameter names
-  @override
-  List<String> get typeParameterNames;
-
-  /// set of super type names
-  @override
-  Set<String> get superTypeNames;
-
-  /// executables that belong to this interface
-  @override
-  List<ExecutableDeclaration> get executableDeclarations;
-
-  /// fields that belong to this interface
-  @override
-  List<FieldDeclaration> get fieldDeclarations;
-
-  /// entry points this interface is reachable through
-  @override
-  Set<String>? get entryPoints;
-
-  /// the relative path of the library
-  @override
-  String get relativePath;
-
-  /// Create a copy of InterfaceDeclaration
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InterfaceDeclarationImplCopyWith<_$InterfaceDeclarationImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/model/internal/internal_declaration_utils.dart
+++ b/lib/src/model/internal/internal_declaration_utils.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:path/path.dart' as path;

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -54,7 +54,11 @@ class InternalExecutableDeclaration implements InternalDeclaration {
           returnTypeName: executableElement.returnType.getDisplayString(),
           returnTypeFullLibraryName:
               executableElement.returnType.element?.librarySource?.fullName,
-          name: executableElement.displayName,
+          // This is a fix for the only method overloading in Dart the `-` operator
+          name: executableElement.isOperator
+              ? (executableElement.parameters.isEmpty ? 'unary' : 'nonunary') +
+                  executableElement.displayName
+              : executableElement.displayName,
           namespace: namespace,
           isDeprecated: executableElement.hasDeprecated,
           isExperimental:

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 
 import '../executable_declaration.dart';

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 
 import '../field_declaration.dart';

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 
 import '../interface_declaration.dart';

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dart_apitool/src/model/internal/internal_declaration.dart';
 import 'package:dart_apitool/src/model/type_alias_declaration.dart';

--- a/lib/src/model/internal/internal_type_usage.dart
+++ b/lib/src/model/internal/internal_type_usage.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:dart_apitool/src/model/internal/internal_declaration_utils.dart';
 

--- a/lib/src/model/package_api.dart
+++ b/lib/src/model/package_api.dart
@@ -6,7 +6,7 @@ part 'package_api.freezed.dart';
 
 /// represents the model of a public package API.
 @freezed
-class PackageApi with _$PackageApi {
+sealed class PackageApi with _$PackageApi {
   const PackageApi._();
 
   const factory PackageApi({

--- a/lib/src/model/package_api.freezed.dart
+++ b/lib/src/model/package_api.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,74 +10,124 @@ part of 'package_api.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$PackageApi {
   /// name of the package
-  String get packageName => throw _privateConstructorUsedError;
+  String get packageName;
 
   /// version of the package
-  String? get packageVersion => throw _privateConstructorUsedError;
+  String? get packageVersion;
 
   /// path to the package
-  String get packagePath => throw _privateConstructorUsedError;
+  String get packagePath;
 
   /// interface declarations this package has
-  List<InterfaceDeclaration> get interfaceDeclarations =>
-      throw _privateConstructorUsedError;
+  List<InterfaceDeclaration> get interfaceDeclarations;
 
   /// root level executable declarations this package has
-  List<ExecutableDeclaration> get executableDeclarations =>
-      throw _privateConstructorUsedError;
+  List<ExecutableDeclaration> get executableDeclarations;
 
   /// root level field declarations this package has
-  List<FieldDeclaration> get fieldDeclarations =>
-      throw _privateConstructorUsedError;
+  List<FieldDeclaration> get fieldDeclarations;
 
   /// type alias declarations this package has
-  List<TypeAliasDeclaration> get typeAliasDeclarations =>
-      throw _privateConstructorUsedError;
+  List<TypeAliasDeclaration> get typeAliasDeclarations;
 
   /// the semantics of this model. This indicates if this model is compatible (e.g. for diffing) with another model
-  Set<PackageApiSemantics> get semantics => throw _privateConstructorUsedError;
+  Set<PackageApiSemantics> get semantics;
 
   /// used Android platform constraints
-  AndroidPlatformConstraints? get androidPlatformConstraints =>
-      throw _privateConstructorUsedError;
+  AndroidPlatformConstraints? get androidPlatformConstraints;
 
   /// used iOS platform constraints
-  IOSPlatformConstraints? get iosPlatformConstraints =>
-      throw _privateConstructorUsedError;
+  IOSPlatformConstraints? get iosPlatformConstraints;
 
   /// type of sdk needed
-  SdkType get sdkType => throw _privateConstructorUsedError;
+  SdkType get sdkType;
 
   /// package dependencies
-  List<PackageDependency> get packageDependencies =>
-      throw _privateConstructorUsedError;
+  List<PackageDependency> get packageDependencies;
 
   /// minimum sdk version
-  Version get minSdkVersion => throw _privateConstructorUsedError;
+  Version get minSdkVersion;
 
   /// the type hierarchy of the public API
-  TypeHierarchy get typeHierarchy => throw _privateConstructorUsedError;
+  TypeHierarchy get typeHierarchy;
 
   /// Create a copy of PackageApi
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $PackageApiCopyWith<PackageApi> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$PackageApiCopyWithImpl<PackageApi>(this as PackageApi, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PackageApi &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
+            const DeepCollectionEquality()
+                .equals(other.interfaceDeclarations, interfaceDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.executableDeclarations, executableDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.fieldDeclarations, fieldDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.typeAliasDeclarations, typeAliasDeclarations) &&
+            const DeepCollectionEquality().equals(other.semantics, semantics) &&
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            const DeepCollectionEquality()
+                .equals(other.packageDependencies, packageDependencies) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            (identical(other.typeHierarchy, typeHierarchy) ||
+                other.typeHierarchy == typeHierarchy));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      packageName,
+      packageVersion,
+      packagePath,
+      const DeepCollectionEquality().hash(interfaceDeclarations),
+      const DeepCollectionEquality().hash(executableDeclarations),
+      const DeepCollectionEquality().hash(fieldDeclarations),
+      const DeepCollectionEquality().hash(typeAliasDeclarations),
+      const DeepCollectionEquality().hash(semantics),
+      androidPlatformConstraints,
+      iosPlatformConstraints,
+      sdkType,
+      const DeepCollectionEquality().hash(packageDependencies),
+      minSdkVersion,
+      typeHierarchy);
+
+  @override
+  String toString() {
+    return 'PackageApi(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, androidPlatformConstraints: $androidPlatformConstraints, iosPlatformConstraints: $iosPlatformConstraints, sdkType: $sdkType, packageDependencies: $packageDependencies, minSdkVersion: $minSdkVersion, typeHierarchy: $typeHierarchy)';
+  }
 }
 
 /// @nodoc
-abstract class $PackageApiCopyWith<$Res> {
+abstract mixin class $PackageApiCopyWith<$Res> {
   factory $PackageApiCopyWith(
-          PackageApi value, $Res Function(PackageApi) then) =
-      _$PackageApiCopyWithImpl<$Res, PackageApi>;
+          PackageApi value, $Res Function(PackageApi) _then) =
+      _$PackageApiCopyWithImpl;
   @useResult
   $Res call(
       {String packageName,
@@ -99,14 +150,11 @@ abstract class $PackageApiCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
-    implements $PackageApiCopyWith<$Res> {
-  _$PackageApiCopyWithImpl(this._value, this._then);
+class _$PackageApiCopyWithImpl<$Res> implements $PackageApiCopyWith<$Res> {
+  _$PackageApiCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PackageApi _self;
+  final $Res Function(PackageApi) _then;
 
   /// Create a copy of PackageApi
   /// with the given fields replaced by the non-null parameter values.
@@ -128,64 +176,64 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
     Object? minSdkVersion = null,
     Object? typeHierarchy = null,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       packageName: null == packageName
-          ? _value.packageName
+          ? _self.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
       packageVersion: freezed == packageVersion
-          ? _value.packageVersion
+          ? _self.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
       packagePath: null == packagePath
-          ? _value.packagePath
+          ? _self.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
       interfaceDeclarations: null == interfaceDeclarations
-          ? _value.interfaceDeclarations
+          ? _self.interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclaration>,
       executableDeclarations: null == executableDeclarations
-          ? _value.executableDeclarations
+          ? _self.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclaration>,
       fieldDeclarations: null == fieldDeclarations
-          ? _value.fieldDeclarations
+          ? _self.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclaration>,
       typeAliasDeclarations: null == typeAliasDeclarations
-          ? _value.typeAliasDeclarations
+          ? _self.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclaration>,
       semantics: null == semantics
-          ? _value.semantics
+          ? _self.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
       androidPlatformConstraints: freezed == androidPlatformConstraints
-          ? _value.androidPlatformConstraints
+          ? _self.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraints?,
       iosPlatformConstraints: freezed == iosPlatformConstraints
-          ? _value.iosPlatformConstraints
+          ? _self.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraints?,
       sdkType: null == sdkType
-          ? _value.sdkType
+          ? _self.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkType,
       packageDependencies: null == packageDependencies
-          ? _value.packageDependencies
+          ? _self.packageDependencies
           : packageDependencies // ignore: cast_nullable_to_non_nullable
               as List<PackageDependency>,
       minSdkVersion: null == minSdkVersion
-          ? _value.minSdkVersion
+          ? _self.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
       typeHierarchy: null == typeHierarchy
-          ? _value.typeHierarchy
+          ? _self.typeHierarchy
           : typeHierarchy // ignore: cast_nullable_to_non_nullable
               as TypeHierarchy,
-    ) as $Val);
+    ));
   }
 
   /// Create a copy of PackageApi
@@ -193,13 +241,13 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
   @override
   @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints {
-    if (_value.androidPlatformConstraints == null) {
+    if (_self.androidPlatformConstraints == null) {
       return null;
     }
 
     return $AndroidPlatformConstraintsCopyWith<$Res>(
-        _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
+        _self.androidPlatformConstraints!, (value) {
+      return _then(_self.copyWith(androidPlatformConstraints: value));
     });
   }
 
@@ -208,140 +256,21 @@ class _$PackageApiCopyWithImpl<$Res, $Val extends PackageApi>
   @override
   @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints {
-    if (_value.iosPlatformConstraints == null) {
+    if (_self.iosPlatformConstraints == null) {
       return null;
     }
 
-    return $IOSPlatformConstraintsCopyWith<$Res>(_value.iosPlatformConstraints!,
+    return $IOSPlatformConstraintsCopyWith<$Res>(_self.iosPlatformConstraints!,
         (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
+      return _then(_self.copyWith(iosPlatformConstraints: value));
     });
   }
 }
 
 /// @nodoc
-abstract class _$$PackageApiImplCopyWith<$Res>
-    implements $PackageApiCopyWith<$Res> {
-  factory _$$PackageApiImplCopyWith(
-          _$PackageApiImpl value, $Res Function(_$PackageApiImpl) then) =
-      __$$PackageApiImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String packageName,
-      String? packageVersion,
-      String packagePath,
-      List<InterfaceDeclaration> interfaceDeclarations,
-      List<ExecutableDeclaration> executableDeclarations,
-      List<FieldDeclaration> fieldDeclarations,
-      List<TypeAliasDeclaration> typeAliasDeclarations,
-      Set<PackageApiSemantics> semantics,
-      AndroidPlatformConstraints? androidPlatformConstraints,
-      IOSPlatformConstraints? iosPlatformConstraints,
-      SdkType sdkType,
-      List<PackageDependency> packageDependencies,
-      Version minSdkVersion,
-      TypeHierarchy typeHierarchy});
 
-  @override
-  $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints;
-  @override
-  $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints;
-}
-
-/// @nodoc
-class __$$PackageApiImplCopyWithImpl<$Res>
-    extends _$PackageApiCopyWithImpl<$Res, _$PackageApiImpl>
-    implements _$$PackageApiImplCopyWith<$Res> {
-  __$$PackageApiImplCopyWithImpl(
-      _$PackageApiImpl _value, $Res Function(_$PackageApiImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PackageApi
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? interfaceDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
-    Object? androidPlatformConstraints = freezed,
-    Object? iosPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? packageDependencies = null,
-    Object? minSdkVersion = null,
-    Object? typeHierarchy = null,
-  }) {
-    return _then(_$PackageApiImpl(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-      packagePath: null == packagePath
-          ? _value.packagePath
-          : packagePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      interfaceDeclarations: null == interfaceDeclarations
-          ? _value._interfaceDeclarations
-          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<InterfaceDeclaration>,
-      executableDeclarations: null == executableDeclarations
-          ? _value._executableDeclarations
-          : executableDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableDeclaration>,
-      fieldDeclarations: null == fieldDeclarations
-          ? _value._fieldDeclarations
-          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<FieldDeclaration>,
-      typeAliasDeclarations: null == typeAliasDeclarations
-          ? _value._typeAliasDeclarations
-          : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<TypeAliasDeclaration>,
-      semantics: null == semantics
-          ? _value._semantics
-          : semantics // ignore: cast_nullable_to_non_nullable
-              as Set<PackageApiSemantics>,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
-          ? _value.androidPlatformConstraints
-          : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
-              as AndroidPlatformConstraints?,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
-          ? _value.iosPlatformConstraints
-          : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
-              as IOSPlatformConstraints?,
-      sdkType: null == sdkType
-          ? _value.sdkType
-          : sdkType // ignore: cast_nullable_to_non_nullable
-              as SdkType,
-      packageDependencies: null == packageDependencies
-          ? _value._packageDependencies
-          : packageDependencies // ignore: cast_nullable_to_non_nullable
-              as List<PackageDependency>,
-      minSdkVersion: null == minSdkVersion
-          ? _value.minSdkVersion
-          : minSdkVersion // ignore: cast_nullable_to_non_nullable
-              as Version,
-      typeHierarchy: null == typeHierarchy
-          ? _value.typeHierarchy
-          : typeHierarchy // ignore: cast_nullable_to_non_nullable
-              as TypeHierarchy,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$PackageApiImpl extends _PackageApi {
-  const _$PackageApiImpl(
+class _PackageApi extends PackageApi {
+  const _PackageApi(
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
@@ -468,16 +397,19 @@ class _$PackageApiImpl extends _PackageApi {
   @override
   final TypeHierarchy typeHierarchy;
 
+  /// Create a copy of PackageApi
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'PackageApi(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, androidPlatformConstraints: $androidPlatformConstraints, iosPlatformConstraints: $iosPlatformConstraints, sdkType: $sdkType, packageDependencies: $packageDependencies, minSdkVersion: $minSdkVersion, typeHierarchy: $typeHierarchy)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PackageApiCopyWith<_PackageApi> get copyWith =>
+      __$PackageApiCopyWithImpl<_PackageApi>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PackageApiImpl &&
+            other is _PackageApi &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -527,93 +459,158 @@ class _$PackageApiImpl extends _PackageApi {
       minSdkVersion,
       typeHierarchy);
 
+  @override
+  String toString() {
+    return 'PackageApi(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, androidPlatformConstraints: $androidPlatformConstraints, iosPlatformConstraints: $iosPlatformConstraints, sdkType: $sdkType, packageDependencies: $packageDependencies, minSdkVersion: $minSdkVersion, typeHierarchy: $typeHierarchy)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PackageApiCopyWith<$Res>
+    implements $PackageApiCopyWith<$Res> {
+  factory _$PackageApiCopyWith(
+          _PackageApi value, $Res Function(_PackageApi) _then) =
+      __$PackageApiCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String packageName,
+      String? packageVersion,
+      String packagePath,
+      List<InterfaceDeclaration> interfaceDeclarations,
+      List<ExecutableDeclaration> executableDeclarations,
+      List<FieldDeclaration> fieldDeclarations,
+      List<TypeAliasDeclaration> typeAliasDeclarations,
+      Set<PackageApiSemantics> semantics,
+      AndroidPlatformConstraints? androidPlatformConstraints,
+      IOSPlatformConstraints? iosPlatformConstraints,
+      SdkType sdkType,
+      List<PackageDependency> packageDependencies,
+      Version minSdkVersion,
+      TypeHierarchy typeHierarchy});
+
+  @override
+  $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints;
+  @override
+  $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints;
+}
+
+/// @nodoc
+class __$PackageApiCopyWithImpl<$Res> implements _$PackageApiCopyWith<$Res> {
+  __$PackageApiCopyWithImpl(this._self, this._then);
+
+  final _PackageApi _self;
+  final $Res Function(_PackageApi) _then;
+
   /// Create a copy of PackageApi
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$PackageApiImplCopyWith<_$PackageApiImpl> get copyWith =>
-      __$$PackageApiImplCopyWithImpl<_$PackageApiImpl>(this, _$identity);
-}
-
-abstract class _PackageApi extends PackageApi {
-  const factory _PackageApi(
-      {required final String packageName,
-      required final String? packageVersion,
-      required final String packagePath,
-      required final List<InterfaceDeclaration> interfaceDeclarations,
-      required final List<ExecutableDeclaration> executableDeclarations,
-      required final List<FieldDeclaration> fieldDeclarations,
-      required final List<TypeAliasDeclaration> typeAliasDeclarations,
-      final Set<PackageApiSemantics> semantics,
-      final AndroidPlatformConstraints? androidPlatformConstraints,
-      final IOSPlatformConstraints? iosPlatformConstraints,
-      required final SdkType sdkType,
-      required final List<PackageDependency> packageDependencies,
-      required final Version minSdkVersion,
-      required final TypeHierarchy typeHierarchy}) = _$PackageApiImpl;
-  const _PackageApi._() : super._();
-
-  /// name of the package
-  @override
-  String get packageName;
-
-  /// version of the package
-  @override
-  String? get packageVersion;
-
-  /// path to the package
-  @override
-  String get packagePath;
-
-  /// interface declarations this package has
-  @override
-  List<InterfaceDeclaration> get interfaceDeclarations;
-
-  /// root level executable declarations this package has
-  @override
-  List<ExecutableDeclaration> get executableDeclarations;
-
-  /// root level field declarations this package has
-  @override
-  List<FieldDeclaration> get fieldDeclarations;
-
-  /// type alias declarations this package has
-  @override
-  List<TypeAliasDeclaration> get typeAliasDeclarations;
-
-  /// the semantics of this model. This indicates if this model is compatible (e.g. for diffing) with another model
-  @override
-  Set<PackageApiSemantics> get semantics;
-
-  /// used Android platform constraints
-  @override
-  AndroidPlatformConstraints? get androidPlatformConstraints;
-
-  /// used iOS platform constraints
-  @override
-  IOSPlatformConstraints? get iosPlatformConstraints;
-
-  /// type of sdk needed
-  @override
-  SdkType get sdkType;
-
-  /// package dependencies
-  @override
-  List<PackageDependency> get packageDependencies;
-
-  /// minimum sdk version
-  @override
-  Version get minSdkVersion;
-
-  /// the type hierarchy of the public API
-  @override
-  TypeHierarchy get typeHierarchy;
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
+    Object? androidPlatformConstraints = freezed,
+    Object? iosPlatformConstraints = freezed,
+    Object? sdkType = null,
+    Object? packageDependencies = null,
+    Object? minSdkVersion = null,
+    Object? typeHierarchy = null,
+  }) {
+    return _then(_PackageApi(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+      packagePath: null == packagePath
+          ? _self.packagePath
+          : packagePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      interfaceDeclarations: null == interfaceDeclarations
+          ? _self._interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclaration>,
+      executableDeclarations: null == executableDeclarations
+          ? _self._executableDeclarations
+          : executableDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableDeclaration>,
+      fieldDeclarations: null == fieldDeclarations
+          ? _self._fieldDeclarations
+          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<FieldDeclaration>,
+      typeAliasDeclarations: null == typeAliasDeclarations
+          ? _self._typeAliasDeclarations
+          : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<TypeAliasDeclaration>,
+      semantics: null == semantics
+          ? _self._semantics
+          : semantics // ignore: cast_nullable_to_non_nullable
+              as Set<PackageApiSemantics>,
+      androidPlatformConstraints: freezed == androidPlatformConstraints
+          ? _self.androidPlatformConstraints
+          : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
+              as AndroidPlatformConstraints?,
+      iosPlatformConstraints: freezed == iosPlatformConstraints
+          ? _self.iosPlatformConstraints
+          : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
+              as IOSPlatformConstraints?,
+      sdkType: null == sdkType
+          ? _self.sdkType
+          : sdkType // ignore: cast_nullable_to_non_nullable
+              as SdkType,
+      packageDependencies: null == packageDependencies
+          ? _self._packageDependencies
+          : packageDependencies // ignore: cast_nullable_to_non_nullable
+              as List<PackageDependency>,
+      minSdkVersion: null == minSdkVersion
+          ? _self.minSdkVersion
+          : minSdkVersion // ignore: cast_nullable_to_non_nullable
+              as Version,
+      typeHierarchy: null == typeHierarchy
+          ? _self.typeHierarchy
+          : typeHierarchy // ignore: cast_nullable_to_non_nullable
+              as TypeHierarchy,
+    ));
+  }
 
   /// Create a copy of PackageApi
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PackageApiImplCopyWith<_$PackageApiImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $AndroidPlatformConstraintsCopyWith<$Res>? get androidPlatformConstraints {
+    if (_self.androidPlatformConstraints == null) {
+      return null;
+    }
+
+    return $AndroidPlatformConstraintsCopyWith<$Res>(
+        _self.androidPlatformConstraints!, (value) {
+      return _then(_self.copyWith(androidPlatformConstraints: value));
+    });
+  }
+
+  /// Create a copy of PackageApi
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $IOSPlatformConstraintsCopyWith<$Res>? get iosPlatformConstraints {
+    if (_self.iosPlatformConstraints == null) {
+      return null;
+    }
+
+    return $IOSPlatformConstraintsCopyWith<$Res>(_self.iosPlatformConstraints!,
+        (value) {
+      return _then(_self.copyWith(iosPlatformConstraints: value));
+    });
+  }
 }
+
+// dart format on

--- a/lib/src/model/package_dependency.dart
+++ b/lib/src/model/package_dependency.dart
@@ -5,7 +5,7 @@ part 'package_dependency.freezed.dart';
 @freezed
 
 /// represents a package dependency
-class PackageDependency with _$PackageDependency {
+sealed class PackageDependency with _$PackageDependency {
   factory PackageDependency({
     /// name of the package
     required String packageName,

--- a/lib/src/model/package_dependency.freezed.dart
+++ b/lib/src/model/package_dependency.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,130 +10,30 @@ part of 'package_dependency.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$PackageDependency {
   /// name of the package
-  String get packageName => throw _privateConstructorUsedError;
+  String get packageName;
 
   /// String representation of the version range. Can be null if the dependency is a path or git dependency
-  String? get packageVersion => throw _privateConstructorUsedError;
+  String? get packageVersion;
 
   /// Create a copy of PackageDependency
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $PackageDependencyCopyWith<PackageDependency> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $PackageDependencyCopyWith<$Res> {
-  factory $PackageDependencyCopyWith(
-          PackageDependency value, $Res Function(PackageDependency) then) =
-      _$PackageDependencyCopyWithImpl<$Res, PackageDependency>;
-  @useResult
-  $Res call({String packageName, String? packageVersion});
-}
-
-/// @nodoc
-class _$PackageDependencyCopyWithImpl<$Res, $Val extends PackageDependency>
-    implements $PackageDependencyCopyWith<$Res> {
-  _$PackageDependencyCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of PackageDependency
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$PackageDependencyImplCopyWith<$Res>
-    implements $PackageDependencyCopyWith<$Res> {
-  factory _$$PackageDependencyImplCopyWith(_$PackageDependencyImpl value,
-          $Res Function(_$PackageDependencyImpl) then) =
-      __$$PackageDependencyImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String packageName, String? packageVersion});
-}
-
-/// @nodoc
-class __$$PackageDependencyImplCopyWithImpl<$Res>
-    extends _$PackageDependencyCopyWithImpl<$Res, _$PackageDependencyImpl>
-    implements _$$PackageDependencyImplCopyWith<$Res> {
-  __$$PackageDependencyImplCopyWithImpl(_$PackageDependencyImpl _value,
-      $Res Function(_$PackageDependencyImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PackageDependency
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-  }) {
-    return _then(_$PackageDependencyImpl(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$PackageDependencyImpl implements _PackageDependency {
-  _$PackageDependencyImpl(
-      {required this.packageName, required this.packageVersion});
-
-  /// name of the package
-  @override
-  final String packageName;
-
-  /// String representation of the version range. Can be null if the dependency is a path or git dependency
-  @override
-  final String? packageVersion;
-
-  @override
-  String toString() {
-    return 'PackageDependency(packageName: $packageName, packageVersion: $packageVersion)';
-  }
+      _$PackageDependencyCopyWithImpl<PackageDependency>(
+          this as PackageDependency, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PackageDependencyImpl &&
+            other is PackageDependency &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -142,33 +43,129 @@ class _$PackageDependencyImpl implements _PackageDependency {
   @override
   int get hashCode => Object.hash(runtimeType, packageName, packageVersion);
 
-  /// Create a copy of PackageDependency
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$PackageDependencyImplCopyWith<_$PackageDependencyImpl> get copyWith =>
-      __$$PackageDependencyImplCopyWithImpl<_$PackageDependencyImpl>(
-          this, _$identity);
+  String toString() {
+    return 'PackageDependency(packageName: $packageName, packageVersion: $packageVersion)';
+  }
 }
 
-abstract class _PackageDependency implements PackageDependency {
-  factory _PackageDependency(
-      {required final String packageName,
-      required final String? packageVersion}) = _$PackageDependencyImpl;
+/// @nodoc
+abstract mixin class $PackageDependencyCopyWith<$Res> {
+  factory $PackageDependencyCopyWith(
+          PackageDependency value, $Res Function(PackageDependency) _then) =
+      _$PackageDependencyCopyWithImpl;
+  @useResult
+  $Res call({String packageName, String? packageVersion});
+}
+
+/// @nodoc
+class _$PackageDependencyCopyWithImpl<$Res>
+    implements $PackageDependencyCopyWith<$Res> {
+  _$PackageDependencyCopyWithImpl(this._self, this._then);
+
+  final PackageDependency _self;
+  final $Res Function(PackageDependency) _then;
+
+  /// Create a copy of PackageDependency
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+  }) {
+    return _then(_self.copyWith(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _PackageDependency implements PackageDependency {
+  _PackageDependency({required this.packageName, required this.packageVersion});
 
   /// name of the package
   @override
-  String get packageName;
+  final String packageName;
 
   /// String representation of the version range. Can be null if the dependency is a path or git dependency
   @override
-  String? get packageVersion;
+  final String? packageVersion;
 
   /// Create a copy of PackageDependency
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PackageDependencyImplCopyWith<_$PackageDependencyImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$PackageDependencyCopyWith<_PackageDependency> get copyWith =>
+      __$PackageDependencyCopyWithImpl<_PackageDependency>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PackageDependency &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, packageName, packageVersion);
+
+  @override
+  String toString() {
+    return 'PackageDependency(packageName: $packageName, packageVersion: $packageVersion)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$PackageDependencyCopyWith<$Res>
+    implements $PackageDependencyCopyWith<$Res> {
+  factory _$PackageDependencyCopyWith(
+          _PackageDependency value, $Res Function(_PackageDependency) _then) =
+      __$PackageDependencyCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String packageName, String? packageVersion});
+}
+
+/// @nodoc
+class __$PackageDependencyCopyWithImpl<$Res>
+    implements _$PackageDependencyCopyWith<$Res> {
+  __$PackageDependencyCopyWithImpl(this._self, this._then);
+
+  final _PackageDependency _self;
+  final $Res Function(_PackageDependency) _then;
+
+  /// Create a copy of PackageDependency
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+  }) {
+    return _then(_PackageDependency(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/model/platform_constraints.dart
+++ b/lib/src/model/platform_constraints.dart
@@ -5,7 +5,7 @@ part 'platform_constraints.freezed.dart';
 @freezed
 
 /// represents iOS platform constraints
-class IOSPlatformConstraints with _$IOSPlatformConstraints {
+sealed class IOSPlatformConstraints with _$IOSPlatformConstraints {
   const factory IOSPlatformConstraints({
     /// minimum iOS version
     required num? minimumOsVersion,
@@ -15,7 +15,7 @@ class IOSPlatformConstraints with _$IOSPlatformConstraints {
 @freezed
 
 /// represents Android platform constraints
-class AndroidPlatformConstraints with _$AndroidPlatformConstraints {
+sealed class AndroidPlatformConstraints with _$AndroidPlatformConstraints {
   const factory AndroidPlatformConstraints({
     /// minimum SDK version
     required int? minSdkVersion,

--- a/lib/src/model/platform_constraints.freezed.dart
+++ b/lib/src/model/platform_constraints.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,116 +10,27 @@ part of 'platform_constraints.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$IOSPlatformConstraints {
   /// minimum iOS version
-  num? get minimumOsVersion => throw _privateConstructorUsedError;
+  num? get minimumOsVersion;
 
   /// Create a copy of IOSPlatformConstraints
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsCopyWith<IOSPlatformConstraints> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $IOSPlatformConstraintsCopyWith<$Res> {
-  factory $IOSPlatformConstraintsCopyWith(IOSPlatformConstraints value,
-          $Res Function(IOSPlatformConstraints) then) =
-      _$IOSPlatformConstraintsCopyWithImpl<$Res, IOSPlatformConstraints>;
-  @useResult
-  $Res call({num? minimumOsVersion});
-}
-
-/// @nodoc
-class _$IOSPlatformConstraintsCopyWithImpl<$Res,
-        $Val extends IOSPlatformConstraints>
-    implements $IOSPlatformConstraintsCopyWith<$Res> {
-  _$IOSPlatformConstraintsCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of IOSPlatformConstraints
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? minimumOsVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      minimumOsVersion: freezed == minimumOsVersion
-          ? _value.minimumOsVersion
-          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
-              as num?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$IOSPlatformConstraintsImplCopyWith<$Res>
-    implements $IOSPlatformConstraintsCopyWith<$Res> {
-  factory _$$IOSPlatformConstraintsImplCopyWith(
-          _$IOSPlatformConstraintsImpl value,
-          $Res Function(_$IOSPlatformConstraintsImpl) then) =
-      __$$IOSPlatformConstraintsImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({num? minimumOsVersion});
-}
-
-/// @nodoc
-class __$$IOSPlatformConstraintsImplCopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsCopyWithImpl<$Res,
-        _$IOSPlatformConstraintsImpl>
-    implements _$$IOSPlatformConstraintsImplCopyWith<$Res> {
-  __$$IOSPlatformConstraintsImplCopyWithImpl(
-      _$IOSPlatformConstraintsImpl _value,
-      $Res Function(_$IOSPlatformConstraintsImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of IOSPlatformConstraints
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? minimumOsVersion = freezed,
-  }) {
-    return _then(_$IOSPlatformConstraintsImpl(
-      minimumOsVersion: freezed == minimumOsVersion
-          ? _value.minimumOsVersion
-          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
-              as num?,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$IOSPlatformConstraintsImpl implements _IOSPlatformConstraints {
-  const _$IOSPlatformConstraintsImpl({required this.minimumOsVersion});
-
-  /// minimum iOS version
-  @override
-  final num? minimumOsVersion;
-
-  @override
-  String toString() {
-    return 'IOSPlatformConstraints(minimumOsVersion: $minimumOsVersion)';
-  }
+      _$IOSPlatformConstraintsCopyWithImpl<IOSPlatformConstraints>(
+          this as IOSPlatformConstraints, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$IOSPlatformConstraintsImpl &&
+            other is IOSPlatformConstraints &&
             (identical(other.minimumOsVersion, minimumOsVersion) ||
                 other.minimumOsVersion == minimumOsVersion));
   }
@@ -126,120 +38,176 @@ class _$IOSPlatformConstraintsImpl implements _IOSPlatformConstraints {
   @override
   int get hashCode => Object.hash(runtimeType, minimumOsVersion);
 
-  /// Create a copy of IOSPlatformConstraints
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$IOSPlatformConstraintsImplCopyWith<_$IOSPlatformConstraintsImpl>
-      get copyWith => __$$IOSPlatformConstraintsImplCopyWithImpl<
-          _$IOSPlatformConstraintsImpl>(this, _$identity);
+  String toString() {
+    return 'IOSPlatformConstraints(minimumOsVersion: $minimumOsVersion)';
+  }
 }
 
-abstract class _IOSPlatformConstraints implements IOSPlatformConstraints {
-  const factory _IOSPlatformConstraints(
-      {required final num? minimumOsVersion}) = _$IOSPlatformConstraintsImpl;
+/// @nodoc
+abstract mixin class $IOSPlatformConstraintsCopyWith<$Res> {
+  factory $IOSPlatformConstraintsCopyWith(IOSPlatformConstraints value,
+          $Res Function(IOSPlatformConstraints) _then) =
+      _$IOSPlatformConstraintsCopyWithImpl;
+  @useResult
+  $Res call({num? minimumOsVersion});
+}
+
+/// @nodoc
+class _$IOSPlatformConstraintsCopyWithImpl<$Res>
+    implements $IOSPlatformConstraintsCopyWith<$Res> {
+  _$IOSPlatformConstraintsCopyWithImpl(this._self, this._then);
+
+  final IOSPlatformConstraints _self;
+  final $Res Function(IOSPlatformConstraints) _then;
+
+  /// Create a copy of IOSPlatformConstraints
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minimumOsVersion = freezed,
+  }) {
+    return _then(_self.copyWith(
+      minimumOsVersion: freezed == minimumOsVersion
+          ? _self.minimumOsVersion
+          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
+              as num?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _IOSPlatformConstraints implements IOSPlatformConstraints {
+  const _IOSPlatformConstraints({required this.minimumOsVersion});
 
   /// minimum iOS version
   @override
-  num? get minimumOsVersion;
+  final num? minimumOsVersion;
 
   /// Create a copy of IOSPlatformConstraints
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$IOSPlatformConstraintsImplCopyWith<_$IOSPlatformConstraintsImpl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$IOSPlatformConstraintsCopyWith<_IOSPlatformConstraints> get copyWith =>
+      __$IOSPlatformConstraintsCopyWithImpl<_IOSPlatformConstraints>(
+          this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _IOSPlatformConstraints &&
+            (identical(other.minimumOsVersion, minimumOsVersion) ||
+                other.minimumOsVersion == minimumOsVersion));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
+
+  @override
+  String toString() {
+    return 'IOSPlatformConstraints(minimumOsVersion: $minimumOsVersion)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$IOSPlatformConstraintsCopyWith<$Res>
+    implements $IOSPlatformConstraintsCopyWith<$Res> {
+  factory _$IOSPlatformConstraintsCopyWith(_IOSPlatformConstraints value,
+          $Res Function(_IOSPlatformConstraints) _then) =
+      __$IOSPlatformConstraintsCopyWithImpl;
+  @override
+  @useResult
+  $Res call({num? minimumOsVersion});
+}
+
+/// @nodoc
+class __$IOSPlatformConstraintsCopyWithImpl<$Res>
+    implements _$IOSPlatformConstraintsCopyWith<$Res> {
+  __$IOSPlatformConstraintsCopyWithImpl(this._self, this._then);
+
+  final _IOSPlatformConstraints _self;
+  final $Res Function(_IOSPlatformConstraints) _then;
+
+  /// Create a copy of IOSPlatformConstraints
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? minimumOsVersion = freezed,
+  }) {
+    return _then(_IOSPlatformConstraints(
+      minimumOsVersion: freezed == minimumOsVersion
+          ? _self.minimumOsVersion
+          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
+              as num?,
+    ));
+  }
 }
 
 /// @nodoc
 mixin _$AndroidPlatformConstraints {
   /// minimum SDK version
-  int? get minSdkVersion => throw _privateConstructorUsedError;
+  int? get minSdkVersion;
 
   /// compile SDK version
-  int? get compileSdkVersion => throw _privateConstructorUsedError;
+  int? get compileSdkVersion;
 
   /// target SDK version
-  int? get targetSdkVersion => throw _privateConstructorUsedError;
+  int? get targetSdkVersion;
 
   /// Create a copy of AndroidPlatformConstraints
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $AndroidPlatformConstraintsCopyWith<AndroidPlatformConstraints>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AndroidPlatformConstraintsCopyWith<$Res> {
-  factory $AndroidPlatformConstraintsCopyWith(AndroidPlatformConstraints value,
-          $Res Function(AndroidPlatformConstraints) then) =
-      _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-          AndroidPlatformConstraints>;
-  @useResult
-  $Res call(
-      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
-}
-
-/// @nodoc
-class _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-        $Val extends AndroidPlatformConstraints>
-    implements $AndroidPlatformConstraintsCopyWith<$Res> {
-  _$AndroidPlatformConstraintsCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AndroidPlatformConstraints
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $AndroidPlatformConstraintsCopyWith<AndroidPlatformConstraints>
+      get copyWith =>
+          _$AndroidPlatformConstraintsCopyWithImpl<AndroidPlatformConstraints>(
+              this as AndroidPlatformConstraints, _$identity);
+
   @override
-  $Res call({
-    Object? minSdkVersion = freezed,
-    Object? compileSdkVersion = freezed,
-    Object? targetSdkVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      minSdkVersion: freezed == minSdkVersion
-          ? _value.minSdkVersion
-          : minSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      compileSdkVersion: freezed == compileSdkVersion
-          ? _value.compileSdkVersion
-          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      targetSdkVersion: freezed == targetSdkVersion
-          ? _value.targetSdkVersion
-          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AndroidPlatformConstraints &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            (identical(other.compileSdkVersion, compileSdkVersion) ||
+                other.compileSdkVersion == compileSdkVersion) &&
+            (identical(other.targetSdkVersion, targetSdkVersion) ||
+                other.targetSdkVersion == targetSdkVersion));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
+
+  @override
+  String toString() {
+    return 'AndroidPlatformConstraints(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
   }
 }
 
 /// @nodoc
-abstract class _$$AndroidPlatformConstraintsImplCopyWith<$Res>
-    implements $AndroidPlatformConstraintsCopyWith<$Res> {
-  factory _$$AndroidPlatformConstraintsImplCopyWith(
-          _$AndroidPlatformConstraintsImpl value,
-          $Res Function(_$AndroidPlatformConstraintsImpl) then) =
-      __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $AndroidPlatformConstraintsCopyWith<$Res> {
+  factory $AndroidPlatformConstraintsCopyWith(AndroidPlatformConstraints value,
+          $Res Function(AndroidPlatformConstraints) _then) =
+      _$AndroidPlatformConstraintsCopyWithImpl;
   @useResult
   $Res call(
       {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
 }
 
 /// @nodoc
-class __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsCopyWithImpl<$Res,
-        _$AndroidPlatformConstraintsImpl>
-    implements _$$AndroidPlatformConstraintsImplCopyWith<$Res> {
-  __$$AndroidPlatformConstraintsImplCopyWithImpl(
-      _$AndroidPlatformConstraintsImpl _value,
-      $Res Function(_$AndroidPlatformConstraintsImpl) _then)
-      : super(_value, _then);
+class _$AndroidPlatformConstraintsCopyWithImpl<$Res>
+    implements $AndroidPlatformConstraintsCopyWith<$Res> {
+  _$AndroidPlatformConstraintsCopyWithImpl(this._self, this._then);
+
+  final AndroidPlatformConstraints _self;
+  final $Res Function(AndroidPlatformConstraints) _then;
 
   /// Create a copy of AndroidPlatformConstraints
   /// with the given fields replaced by the non-null parameter values.
@@ -250,17 +218,17 @@ class __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>
     Object? compileSdkVersion = freezed,
     Object? targetSdkVersion = freezed,
   }) {
-    return _then(_$AndroidPlatformConstraintsImpl(
+    return _then(_self.copyWith(
       minSdkVersion: freezed == minSdkVersion
-          ? _value.minSdkVersion
+          ? _self.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
       compileSdkVersion: freezed == compileSdkVersion
-          ? _value.compileSdkVersion
+          ? _self.compileSdkVersion
           : compileSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
       targetSdkVersion: freezed == targetSdkVersion
-          ? _value.targetSdkVersion
+          ? _self.targetSdkVersion
           : targetSdkVersion // ignore: cast_nullable_to_non_nullable
               as int?,
     ));
@@ -269,8 +237,8 @@ class __$$AndroidPlatformConstraintsImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$AndroidPlatformConstraintsImpl implements _AndroidPlatformConstraints {
-  const _$AndroidPlatformConstraintsImpl(
+class _AndroidPlatformConstraints implements AndroidPlatformConstraints {
+  const _AndroidPlatformConstraints(
       {required this.minSdkVersion,
       required this.compileSdkVersion,
       required this.targetSdkVersion});
@@ -287,16 +255,20 @@ class _$AndroidPlatformConstraintsImpl implements _AndroidPlatformConstraints {
   @override
   final int? targetSdkVersion;
 
+  /// Create a copy of AndroidPlatformConstraints
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'AndroidPlatformConstraints(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$AndroidPlatformConstraintsCopyWith<_AndroidPlatformConstraints>
+      get copyWith => __$AndroidPlatformConstraintsCopyWithImpl<
+          _AndroidPlatformConstraints>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AndroidPlatformConstraintsImpl &&
+            other is _AndroidPlatformConstraints &&
             (identical(other.minSdkVersion, minSdkVersion) ||
                 other.minSdkVersion == minSdkVersion) &&
             (identical(other.compileSdkVersion, compileSdkVersion) ||
@@ -309,39 +281,57 @@ class _$AndroidPlatformConstraintsImpl implements _AndroidPlatformConstraints {
   int get hashCode => Object.hash(
       runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
 
+  @override
+  String toString() {
+    return 'AndroidPlatformConstraints(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$AndroidPlatformConstraintsCopyWith<$Res>
+    implements $AndroidPlatformConstraintsCopyWith<$Res> {
+  factory _$AndroidPlatformConstraintsCopyWith(
+          _AndroidPlatformConstraints value,
+          $Res Function(_AndroidPlatformConstraints) _then) =
+      __$AndroidPlatformConstraintsCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
+}
+
+/// @nodoc
+class __$AndroidPlatformConstraintsCopyWithImpl<$Res>
+    implements _$AndroidPlatformConstraintsCopyWith<$Res> {
+  __$AndroidPlatformConstraintsCopyWithImpl(this._self, this._then);
+
+  final _AndroidPlatformConstraints _self;
+  final $Res Function(_AndroidPlatformConstraints) _then;
+
   /// Create a copy of AndroidPlatformConstraints
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$AndroidPlatformConstraintsImplCopyWith<_$AndroidPlatformConstraintsImpl>
-      get copyWith => __$$AndroidPlatformConstraintsImplCopyWithImpl<
-          _$AndroidPlatformConstraintsImpl>(this, _$identity);
+  $Res call({
+    Object? minSdkVersion = freezed,
+    Object? compileSdkVersion = freezed,
+    Object? targetSdkVersion = freezed,
+  }) {
+    return _then(_AndroidPlatformConstraints(
+      minSdkVersion: freezed == minSdkVersion
+          ? _self.minSdkVersion
+          : minSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      compileSdkVersion: freezed == compileSdkVersion
+          ? _self.compileSdkVersion
+          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      targetSdkVersion: freezed == targetSdkVersion
+          ? _self.targetSdkVersion
+          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
 }
 
-abstract class _AndroidPlatformConstraints
-    implements AndroidPlatformConstraints {
-  const factory _AndroidPlatformConstraints(
-      {required final int? minSdkVersion,
-      required final int? compileSdkVersion,
-      required final int? targetSdkVersion}) = _$AndroidPlatformConstraintsImpl;
-
-  /// minimum SDK version
-  @override
-  int? get minSdkVersion;
-
-  /// compile SDK version
-  @override
-  int? get compileSdkVersion;
-
-  /// target SDK version
-  @override
-  int? get targetSdkVersion;
-
-  /// Create a copy of AndroidPlatformConstraints
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AndroidPlatformConstraintsImplCopyWith<_$AndroidPlatformConstraintsImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/model/type_alias_declaration.dart
+++ b/lib/src/model/type_alias_declaration.dart
@@ -6,7 +6,9 @@ part 'type_alias_declaration.freezed.dart';
 
 /// represents a found TypeAliasDeclaration
 @freezed
-class TypeAliasDeclaration with _$TypeAliasDeclaration implements Declaration {
+sealed class TypeAliasDeclaration
+    with _$TypeAliasDeclaration
+    implements Declaration {
   const TypeAliasDeclaration._();
 
   /// the signature of this type alias declaration.

--- a/lib/src/model/type_alias_declaration.freezed.dart
+++ b/lib/src/model/type_alias_declaration.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,112 +10,76 @@ part of 'type_alias_declaration.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$TypeAliasDeclaration {
   /// name of this type alias
-  String get name => throw _privateConstructorUsedError;
+  String get name;
 
   /// name of the aliased type
-  String get aliasedTypeName => throw _privateConstructorUsedError;
+  String get aliasedTypeName;
 
   /// whether this type alias is deprecated
-  bool get isDeprecated => throw _privateConstructorUsedError;
+  bool get isDeprecated;
 
   /// whether this type alias is experimental
-  bool get isExperimental => throw _privateConstructorUsedError;
+  bool get isExperimental;
 
   /// entry points this type alias is reachable through
-  Set<String>? get entryPoints => throw _privateConstructorUsedError;
+  Set<String>? get entryPoints;
 
   /// the relative path of the library
-  String get relativePath => throw _privateConstructorUsedError;
+  String get relativePath;
 
   /// Create a copy of TypeAliasDeclaration
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $TypeAliasDeclarationCopyWith<TypeAliasDeclaration> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $TypeAliasDeclarationCopyWith<$Res> {
-  factory $TypeAliasDeclarationCopyWith(TypeAliasDeclaration value,
-          $Res Function(TypeAliasDeclaration) then) =
-      _$TypeAliasDeclarationCopyWithImpl<$Res, TypeAliasDeclaration>;
-  @useResult
-  $Res call(
-      {String name,
-      String aliasedTypeName,
-      bool isDeprecated,
-      bool isExperimental,
-      Set<String>? entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$TypeAliasDeclarationCopyWithImpl<$Res,
-        $Val extends TypeAliasDeclaration>
-    implements $TypeAliasDeclarationCopyWith<$Res> {
-  _$TypeAliasDeclarationCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of TypeAliasDeclaration
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $TypeAliasDeclarationCopyWith<TypeAliasDeclaration> get copyWith =>
+      _$TypeAliasDeclarationCopyWithImpl<TypeAliasDeclaration>(
+          this as TypeAliasDeclaration, _$identity);
+
   @override
-  $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? entryPoints = freezed,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      aliasedTypeName: null == aliasedTypeName
-          ? _value.aliasedTypeName
-          : aliasedTypeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: freezed == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>?,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is TypeAliasDeclaration &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.aliasedTypeName, aliasedTypeName) ||
+                other.aliasedTypeName == aliasedTypeName) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      aliasedTypeName,
+      isDeprecated,
+      isExperimental,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'TypeAliasDeclaration(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$TypeAliasDeclarationImplCopyWith<$Res>
-    implements $TypeAliasDeclarationCopyWith<$Res> {
-  factory _$$TypeAliasDeclarationImplCopyWith(_$TypeAliasDeclarationImpl value,
-          $Res Function(_$TypeAliasDeclarationImpl) then) =
-      __$$TypeAliasDeclarationImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $TypeAliasDeclarationCopyWith<$Res> {
+  factory $TypeAliasDeclarationCopyWith(TypeAliasDeclaration value,
+          $Res Function(TypeAliasDeclaration) _then) =
+      _$TypeAliasDeclarationCopyWithImpl;
   @useResult
   $Res call(
       {String name,
@@ -126,12 +91,12 @@ abstract class _$$TypeAliasDeclarationImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$TypeAliasDeclarationImplCopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationCopyWithImpl<$Res, _$TypeAliasDeclarationImpl>
-    implements _$$TypeAliasDeclarationImplCopyWith<$Res> {
-  __$$TypeAliasDeclarationImplCopyWithImpl(_$TypeAliasDeclarationImpl _value,
-      $Res Function(_$TypeAliasDeclarationImpl) _then)
-      : super(_value, _then);
+class _$TypeAliasDeclarationCopyWithImpl<$Res>
+    implements $TypeAliasDeclarationCopyWith<$Res> {
+  _$TypeAliasDeclarationCopyWithImpl(this._self, this._then);
+
+  final TypeAliasDeclaration _self;
+  final $Res Function(TypeAliasDeclaration) _then;
 
   /// Create a copy of TypeAliasDeclaration
   /// with the given fields replaced by the non-null parameter values.
@@ -145,29 +110,29 @@ class __$$TypeAliasDeclarationImplCopyWithImpl<$Res>
     Object? entryPoints = freezed,
     Object? relativePath = null,
   }) {
-    return _then(_$TypeAliasDeclarationImpl(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       aliasedTypeName: null == aliasedTypeName
-          ? _value.aliasedTypeName
+          ? _self.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       entryPoints: freezed == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>?,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -176,8 +141,9 @@ class __$$TypeAliasDeclarationImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$TypeAliasDeclarationImpl extends _TypeAliasDeclaration {
-  const _$TypeAliasDeclarationImpl(
+class _TypeAliasDeclaration extends TypeAliasDeclaration
+    implements Declaration {
+  const _TypeAliasDeclaration(
       {required this.name,
       required this.aliasedTypeName,
       required this.isDeprecated,
@@ -220,16 +186,20 @@ class _$TypeAliasDeclarationImpl extends _TypeAliasDeclaration {
   @override
   final String relativePath;
 
+  /// Create a copy of TypeAliasDeclaration
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'TypeAliasDeclaration(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TypeAliasDeclarationCopyWith<_TypeAliasDeclaration> get copyWith =>
+      __$TypeAliasDeclarationCopyWithImpl<_TypeAliasDeclaration>(
+          this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TypeAliasDeclarationImpl &&
+            other is _TypeAliasDeclaration &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.aliasedTypeName, aliasedTypeName) ||
                 other.aliasedTypeName == aliasedTypeName) &&
@@ -253,56 +223,76 @@ class _$TypeAliasDeclarationImpl extends _TypeAliasDeclaration {
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
+  @override
+  String toString() {
+    return 'TypeAliasDeclaration(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TypeAliasDeclarationCopyWith<$Res>
+    implements $TypeAliasDeclarationCopyWith<$Res> {
+  factory _$TypeAliasDeclarationCopyWith(_TypeAliasDeclaration value,
+          $Res Function(_TypeAliasDeclaration) _then) =
+      __$TypeAliasDeclarationCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      String aliasedTypeName,
+      bool isDeprecated,
+      bool isExperimental,
+      Set<String>? entryPoints,
+      String relativePath});
+}
+
+/// @nodoc
+class __$TypeAliasDeclarationCopyWithImpl<$Res>
+    implements _$TypeAliasDeclarationCopyWith<$Res> {
+  __$TypeAliasDeclarationCopyWithImpl(this._self, this._then);
+
+  final _TypeAliasDeclaration _self;
+  final $Res Function(_TypeAliasDeclaration) _then;
+
   /// Create a copy of TypeAliasDeclaration
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TypeAliasDeclarationImplCopyWith<_$TypeAliasDeclarationImpl>
-      get copyWith =>
-          __$$TypeAliasDeclarationImplCopyWithImpl<_$TypeAliasDeclarationImpl>(
-              this, _$identity);
+  $Res call({
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? entryPoints = freezed,
+    Object? relativePath = null,
+  }) {
+    return _then(_TypeAliasDeclaration(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      aliasedTypeName: null == aliasedTypeName
+          ? _self.aliasedTypeName
+          : aliasedTypeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: freezed == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>?,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
-abstract class _TypeAliasDeclaration extends TypeAliasDeclaration
-    implements Declaration {
-  const factory _TypeAliasDeclaration(
-      {required final String name,
-      required final String aliasedTypeName,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      final Set<String>? entryPoints,
-      required final String relativePath}) = _$TypeAliasDeclarationImpl;
-  const _TypeAliasDeclaration._() : super._();
-
-  /// name of this type alias
-  @override
-  String get name;
-
-  /// name of the aliased type
-  @override
-  String get aliasedTypeName;
-
-  /// whether this type alias is deprecated
-  @override
-  bool get isDeprecated;
-
-  /// whether this type alias is experimental
-  @override
-  bool get isExperimental;
-
-  /// entry points this type alias is reachable through
-  @override
-  Set<String>? get entryPoints;
-
-  /// the relative path of the library
-  @override
-  String get relativePath;
-
-  /// Create a copy of TypeAliasDeclaration
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TypeAliasDeclarationImplCopyWith<_$TypeAliasDeclarationImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -13,7 +13,7 @@ part 'type_hierarchy.freezed.dart';
 /// represents a type identifier
 /// consists of name and full library name
 @freezed
-class TypeIdentifier with _$TypeIdentifier {
+sealed class TypeIdentifier with _$TypeIdentifier {
   const TypeIdentifier._();
 
   /// returns true if this type identifier contains the nullable flag
@@ -282,7 +282,7 @@ class TypeHierarchy {
 
 /// represents a type in the type hierarchy
 @freezed
-class _TypeHierarchyItem with _$TypeHierarchyItem {
+sealed class _TypeHierarchyItem with _$TypeHierarchyItem {
   const _TypeHierarchyItem._();
 
   const factory _TypeHierarchyItem({

--- a/lib/src/model/type_hierarchy.freezed.dart
+++ b/lib/src/model/type_hierarchy.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,94 +10,65 @@ part of 'type_hierarchy.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$TypeIdentifier {
   /// the name of this type
-  String get typeName => throw _privateConstructorUsedError;
+  String get typeName;
 
   /// the name of the package defining that type
-  String get packageName => throw _privateConstructorUsedError;
+  String get packageName;
 
   /// the library path inside the package defining that type
-  String get packageRelativeLibraryPath => throw _privateConstructorUsedError;
+  String get packageRelativeLibraryPath;
 
   /// Create a copy of TypeIdentifier
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $TypeIdentifierCopyWith<TypeIdentifier> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$TypeIdentifierCopyWithImpl<TypeIdentifier>(
+          this as TypeIdentifier, _$identity);
 
-/// @nodoc
-abstract class $TypeIdentifierCopyWith<$Res> {
-  factory $TypeIdentifierCopyWith(
-          TypeIdentifier value, $Res Function(TypeIdentifier) then) =
-      _$TypeIdentifierCopyWithImpl<$Res, TypeIdentifier>;
-  @useResult
-  $Res call(
-      {String typeName, String packageName, String packageRelativeLibraryPath});
-}
-
-/// @nodoc
-class _$TypeIdentifierCopyWithImpl<$Res, $Val extends TypeIdentifier>
-    implements $TypeIdentifierCopyWith<$Res> {
-  _$TypeIdentifierCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of TypeIdentifier
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
   @override
-  $Res call({
-    Object? typeName = null,
-    Object? packageName = null,
-    Object? packageRelativeLibraryPath = null,
-  }) {
-    return _then(_value.copyWith(
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageRelativeLibraryPath: null == packageRelativeLibraryPath
-          ? _value.packageRelativeLibraryPath
-          : packageRelativeLibraryPath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is TypeIdentifier &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageRelativeLibraryPath,
+                    packageRelativeLibraryPath) ||
+                other.packageRelativeLibraryPath ==
+                    packageRelativeLibraryPath));
   }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, typeName, packageName, packageRelativeLibraryPath);
 }
 
 /// @nodoc
-abstract class _$$TypeIdentifierImplCopyWith<$Res>
-    implements $TypeIdentifierCopyWith<$Res> {
-  factory _$$TypeIdentifierImplCopyWith(_$TypeIdentifierImpl value,
-          $Res Function(_$TypeIdentifierImpl) then) =
-      __$$TypeIdentifierImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $TypeIdentifierCopyWith<$Res> {
+  factory $TypeIdentifierCopyWith(
+          TypeIdentifier value, $Res Function(TypeIdentifier) _then) =
+      _$TypeIdentifierCopyWithImpl;
   @useResult
   $Res call(
       {String typeName, String packageName, String packageRelativeLibraryPath});
 }
 
 /// @nodoc
-class __$$TypeIdentifierImplCopyWithImpl<$Res>
-    extends _$TypeIdentifierCopyWithImpl<$Res, _$TypeIdentifierImpl>
-    implements _$$TypeIdentifierImplCopyWith<$Res> {
-  __$$TypeIdentifierImplCopyWithImpl(
-      _$TypeIdentifierImpl _value, $Res Function(_$TypeIdentifierImpl) _then)
-      : super(_value, _then);
+class _$TypeIdentifierCopyWithImpl<$Res>
+    implements $TypeIdentifierCopyWith<$Res> {
+  _$TypeIdentifierCopyWithImpl(this._self, this._then);
+
+  final TypeIdentifier _self;
+  final $Res Function(TypeIdentifier) _then;
 
   /// Create a copy of TypeIdentifier
   /// with the given fields replaced by the non-null parameter values.
@@ -107,17 +79,17 @@ class __$$TypeIdentifierImplCopyWithImpl<$Res>
     Object? packageName = null,
     Object? packageRelativeLibraryPath = null,
   }) {
-    return _then(_$TypeIdentifierImpl(
+    return _then(_self.copyWith(
       typeName: null == typeName
-          ? _value.typeName
+          ? _self.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
       packageName: null == packageName
-          ? _value.packageName
+          ? _self.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
       packageRelativeLibraryPath: null == packageRelativeLibraryPath
-          ? _value.packageRelativeLibraryPath
+          ? _self.packageRelativeLibraryPath
           : packageRelativeLibraryPath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -126,8 +98,8 @@ class __$$TypeIdentifierImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$TypeIdentifierImpl extends _TypeIdentifier {
-  const _$TypeIdentifierImpl(
+class _TypeIdentifier extends TypeIdentifier {
+  const _TypeIdentifier(
       {required this.typeName,
       required this.packageName,
       required this.packageRelativeLibraryPath})
@@ -145,11 +117,19 @@ class _$TypeIdentifierImpl extends _TypeIdentifier {
   @override
   final String packageRelativeLibraryPath;
 
+  /// Create a copy of TypeIdentifier
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TypeIdentifierCopyWith<_TypeIdentifier> get copyWith =>
+      __$TypeIdentifierCopyWithImpl<_TypeIdentifier>(this, _$identity);
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TypeIdentifierImpl &&
+            other is _TypeIdentifier &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.packageName, packageName) ||
@@ -163,65 +143,91 @@ class _$TypeIdentifierImpl extends _TypeIdentifier {
   @override
   int get hashCode => Object.hash(
       runtimeType, typeName, packageName, packageRelativeLibraryPath);
-
-  /// Create a copy of TypeIdentifier
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$TypeIdentifierImplCopyWith<_$TypeIdentifierImpl> get copyWith =>
-      __$$TypeIdentifierImplCopyWithImpl<_$TypeIdentifierImpl>(
-          this, _$identity);
 }
 
-abstract class _TypeIdentifier extends TypeIdentifier {
-  const factory _TypeIdentifier(
-      {required final String typeName,
-      required final String packageName,
-      required final String packageRelativeLibraryPath}) = _$TypeIdentifierImpl;
-  const _TypeIdentifier._() : super._();
-
-  /// the name of this type
+/// @nodoc
+abstract mixin class _$TypeIdentifierCopyWith<$Res>
+    implements $TypeIdentifierCopyWith<$Res> {
+  factory _$TypeIdentifierCopyWith(
+          _TypeIdentifier value, $Res Function(_TypeIdentifier) _then) =
+      __$TypeIdentifierCopyWithImpl;
   @override
-  String get typeName;
+  @useResult
+  $Res call(
+      {String typeName, String packageName, String packageRelativeLibraryPath});
+}
 
-  /// the name of the package defining that type
-  @override
-  String get packageName;
+/// @nodoc
+class __$TypeIdentifierCopyWithImpl<$Res>
+    implements _$TypeIdentifierCopyWith<$Res> {
+  __$TypeIdentifierCopyWithImpl(this._self, this._then);
 
-  /// the library path inside the package defining that type
-  @override
-  String get packageRelativeLibraryPath;
+  final _TypeIdentifier _self;
+  final $Res Function(_TypeIdentifier) _then;
 
   /// Create a copy of TypeIdentifier
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TypeIdentifierImplCopyWith<_$TypeIdentifierImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeName = null,
+    Object? packageName = null,
+    Object? packageRelativeLibraryPath = null,
+  }) {
+    return _then(_TypeIdentifier(
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageRelativeLibraryPath: null == packageRelativeLibraryPath
+          ? _self.packageRelativeLibraryPath
+          : packageRelativeLibraryPath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
 
 /// @nodoc
 mixin _$TypeHierarchyItem {
   /// the identifier of this type
-  TypeIdentifier get typeIdentifier => throw _privateConstructorUsedError;
+  TypeIdentifier get typeIdentifier;
 
   /// the type identifiers of the super types of this type
-  Set<TypeIdentifier> get baseTypeIdentifiers =>
-      throw _privateConstructorUsedError;
+  Set<TypeIdentifier> get baseTypeIdentifiers;
 
   /// Create a copy of _TypeHierarchyItem
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   _$TypeHierarchyItemCopyWith<_TypeHierarchyItem> get copyWith =>
-      throw _privateConstructorUsedError;
+      __$TypeHierarchyItemCopyWithImpl<_TypeHierarchyItem>(
+          this as _TypeHierarchyItem, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _TypeHierarchyItem &&
+            (identical(other.typeIdentifier, typeIdentifier) ||
+                other.typeIdentifier == typeIdentifier) &&
+            const DeepCollectionEquality()
+                .equals(other.baseTypeIdentifiers, baseTypeIdentifiers));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, typeIdentifier,
+      const DeepCollectionEquality().hash(baseTypeIdentifiers));
 }
 
 /// @nodoc
-abstract class _$TypeHierarchyItemCopyWith<$Res> {
+abstract mixin class _$TypeHierarchyItemCopyWith<$Res> {
   factory _$TypeHierarchyItemCopyWith(
-          _TypeHierarchyItem value, $Res Function(_TypeHierarchyItem) then) =
-      __$TypeHierarchyItemCopyWithImpl<$Res, _TypeHierarchyItem>;
+          _TypeHierarchyItem value, $Res Function(_TypeHierarchyItem) _then) =
+      __$TypeHierarchyItemCopyWithImpl;
   @useResult
   $Res call(
       {TypeIdentifier typeIdentifier, Set<TypeIdentifier> baseTypeIdentifiers});
@@ -230,14 +236,12 @@ abstract class _$TypeHierarchyItemCopyWith<$Res> {
 }
 
 /// @nodoc
-class __$TypeHierarchyItemCopyWithImpl<$Res, $Val extends _TypeHierarchyItem>
+class __$TypeHierarchyItemCopyWithImpl<$Res>
     implements _$TypeHierarchyItemCopyWith<$Res> {
-  __$TypeHierarchyItemCopyWithImpl(this._value, this._then);
+  __$TypeHierarchyItemCopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final _TypeHierarchyItem _self;
+  final $Res Function(_TypeHierarchyItem) _then;
 
   /// Create a copy of _TypeHierarchyItem
   /// with the given fields replaced by the non-null parameter values.
@@ -247,16 +251,16 @@ class __$TypeHierarchyItemCopyWithImpl<$Res, $Val extends _TypeHierarchyItem>
     Object? typeIdentifier = null,
     Object? baseTypeIdentifiers = null,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       typeIdentifier: null == typeIdentifier
-          ? _value.typeIdentifier
+          ? _self.typeIdentifier
           : typeIdentifier // ignore: cast_nullable_to_non_nullable
               as TypeIdentifier,
       baseTypeIdentifiers: null == baseTypeIdentifiers
-          ? _value.baseTypeIdentifiers
+          ? _self.baseTypeIdentifiers
           : baseTypeIdentifiers // ignore: cast_nullable_to_non_nullable
               as Set<TypeIdentifier>,
-    ) as $Val);
+    ));
   }
 
   /// Create a copy of _TypeHierarchyItem
@@ -264,60 +268,16 @@ class __$TypeHierarchyItemCopyWithImpl<$Res, $Val extends _TypeHierarchyItem>
   @override
   @pragma('vm:prefer-inline')
   $TypeIdentifierCopyWith<$Res> get typeIdentifier {
-    return $TypeIdentifierCopyWith<$Res>(_value.typeIdentifier, (value) {
-      return _then(_value.copyWith(typeIdentifier: value) as $Val);
+    return $TypeIdentifierCopyWith<$Res>(_self.typeIdentifier, (value) {
+      return _then(_self.copyWith(typeIdentifier: value));
     });
   }
 }
 
 /// @nodoc
-abstract class _$$_TypeHierarchyItemImplCopyWith<$Res>
-    implements _$TypeHierarchyItemCopyWith<$Res> {
-  factory _$$_TypeHierarchyItemImplCopyWith(_$_TypeHierarchyItemImpl value,
-          $Res Function(_$_TypeHierarchyItemImpl) then) =
-      __$$_TypeHierarchyItemImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {TypeIdentifier typeIdentifier, Set<TypeIdentifier> baseTypeIdentifiers});
 
-  @override
-  $TypeIdentifierCopyWith<$Res> get typeIdentifier;
-}
-
-/// @nodoc
-class __$$_TypeHierarchyItemImplCopyWithImpl<$Res>
-    extends __$TypeHierarchyItemCopyWithImpl<$Res, _$_TypeHierarchyItemImpl>
-    implements _$$_TypeHierarchyItemImplCopyWith<$Res> {
-  __$$_TypeHierarchyItemImplCopyWithImpl(_$_TypeHierarchyItemImpl _value,
-      $Res Function(_$_TypeHierarchyItemImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of _TypeHierarchyItem
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? typeIdentifier = null,
-    Object? baseTypeIdentifiers = null,
-  }) {
-    return _then(_$_TypeHierarchyItemImpl(
-      typeIdentifier: null == typeIdentifier
-          ? _value.typeIdentifier
-          : typeIdentifier // ignore: cast_nullable_to_non_nullable
-              as TypeIdentifier,
-      baseTypeIdentifiers: null == baseTypeIdentifiers
-          ? _value._baseTypeIdentifiers
-          : baseTypeIdentifiers // ignore: cast_nullable_to_non_nullable
-              as Set<TypeIdentifier>,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$_TypeHierarchyItemImpl extends __TypeHierarchyItem {
-  const _$_TypeHierarchyItemImpl(
+class __TypeHierarchyItem extends _TypeHierarchyItem {
+  const __TypeHierarchyItem(
       {required this.typeIdentifier,
       required final Set<TypeIdentifier> baseTypeIdentifiers})
       : _baseTypeIdentifiers = baseTypeIdentifiers,
@@ -339,11 +299,19 @@ class _$_TypeHierarchyItemImpl extends __TypeHierarchyItem {
     return EqualUnmodifiableSetView(_baseTypeIdentifiers);
   }
 
+  /// Create a copy of _TypeHierarchyItem
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$_TypeHierarchyItemCopyWith<__TypeHierarchyItem> get copyWith =>
+      __$_TypeHierarchyItemCopyWithImpl<__TypeHierarchyItem>(this, _$identity);
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_TypeHierarchyItemImpl &&
+            other is __TypeHierarchyItem &&
             (identical(other.typeIdentifier, typeIdentifier) ||
                 other.typeIdentifier == typeIdentifier) &&
             const DeepCollectionEquality()
@@ -353,36 +321,60 @@ class _$_TypeHierarchyItemImpl extends __TypeHierarchyItem {
   @override
   int get hashCode => Object.hash(runtimeType, typeIdentifier,
       const DeepCollectionEquality().hash(_baseTypeIdentifiers));
+}
+
+/// @nodoc
+abstract mixin class _$_TypeHierarchyItemCopyWith<$Res>
+    implements _$TypeHierarchyItemCopyWith<$Res> {
+  factory _$_TypeHierarchyItemCopyWith(
+          __TypeHierarchyItem value, $Res Function(__TypeHierarchyItem) _then) =
+      __$_TypeHierarchyItemCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {TypeIdentifier typeIdentifier, Set<TypeIdentifier> baseTypeIdentifiers});
+
+  @override
+  $TypeIdentifierCopyWith<$Res> get typeIdentifier;
+}
+
+/// @nodoc
+class __$_TypeHierarchyItemCopyWithImpl<$Res>
+    implements _$_TypeHierarchyItemCopyWith<$Res> {
+  __$_TypeHierarchyItemCopyWithImpl(this._self, this._then);
+
+  final __TypeHierarchyItem _self;
+  final $Res Function(__TypeHierarchyItem) _then;
 
   /// Create a copy of _TypeHierarchyItem
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$_TypeHierarchyItemImplCopyWith<_$_TypeHierarchyItemImpl> get copyWith =>
-      __$$_TypeHierarchyItemImplCopyWithImpl<_$_TypeHierarchyItemImpl>(
-          this, _$identity);
-}
-
-abstract class __TypeHierarchyItem extends _TypeHierarchyItem {
-  const factory __TypeHierarchyItem(
-          {required final TypeIdentifier typeIdentifier,
-          required final Set<TypeIdentifier> baseTypeIdentifiers}) =
-      _$_TypeHierarchyItemImpl;
-  const __TypeHierarchyItem._() : super._();
-
-  /// the identifier of this type
-  @override
-  TypeIdentifier get typeIdentifier;
-
-  /// the type identifiers of the super types of this type
-  @override
-  Set<TypeIdentifier> get baseTypeIdentifiers;
+  $Res call({
+    Object? typeIdentifier = null,
+    Object? baseTypeIdentifiers = null,
+  }) {
+    return _then(__TypeHierarchyItem(
+      typeIdentifier: null == typeIdentifier
+          ? _self.typeIdentifier
+          : typeIdentifier // ignore: cast_nullable_to_non_nullable
+              as TypeIdentifier,
+      baseTypeIdentifiers: null == baseTypeIdentifiers
+          ? _self._baseTypeIdentifiers
+          : baseTypeIdentifiers // ignore: cast_nullable_to_non_nullable
+              as Set<TypeIdentifier>,
+    ));
+  }
 
   /// Create a copy of _TypeHierarchyItem
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$_TypeHierarchyItemImplCopyWith<_$_TypeHierarchyItemImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $TypeIdentifierCopyWith<$Res> get typeIdentifier {
+    return $TypeIdentifierCopyWith<$Res>(_self.typeIdentifier, (value) {
+      return _then(_self.copyWith(typeIdentifier: value));
+    });
+  }
 }
+
+// dart format on

--- a/lib/src/model/type_usage.dart
+++ b/lib/src/model/type_usage.dart
@@ -6,7 +6,7 @@ part 'type_usage.freezed.dart';
 
 /// represents the usage of a type
 @freezed
-class TypeUsage with _$TypeUsage {
+sealed class TypeUsage with _$TypeUsage {
   const TypeUsage._();
 
   const factory TypeUsage({

--- a/lib/src/model/type_usage.freezed.dart
+++ b/lib/src/model/type_usage.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,83 +10,53 @@ part of 'type_usage.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$TypeUsage {
   /// kind of usage
-  TypeUsageKind get kind => throw _privateConstructorUsedError;
+  TypeUsageKind get kind;
 
   /// the name of the referring element
-  String get referringElementName => throw _privateConstructorUsedError;
+  String get referringElementName;
 
   /// defines if the usage happened in a visibleForTesting context
-  bool get isVisibleForTesting => throw _privateConstructorUsedError;
+  bool get isVisibleForTesting;
 
   /// Create a copy of TypeUsage
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $TypeUsageCopyWith<TypeUsage> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $TypeUsageCopyWith<$Res> {
-  factory $TypeUsageCopyWith(TypeUsage value, $Res Function(TypeUsage) then) =
-      _$TypeUsageCopyWithImpl<$Res, TypeUsage>;
-  @useResult
-  $Res call(
-      {TypeUsageKind kind,
-      String referringElementName,
-      bool isVisibleForTesting});
-}
-
-/// @nodoc
-class _$TypeUsageCopyWithImpl<$Res, $Val extends TypeUsage>
-    implements $TypeUsageCopyWith<$Res> {
-  _$TypeUsageCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of TypeUsage
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $TypeUsageCopyWith<TypeUsage> get copyWith =>
+      _$TypeUsageCopyWithImpl<TypeUsage>(this as TypeUsage, _$identity);
+
   @override
-  $Res call({
-    Object? kind = null,
-    Object? referringElementName = null,
-    Object? isVisibleForTesting = null,
-  }) {
-    return _then(_value.copyWith(
-      kind: null == kind
-          ? _value.kind
-          : kind // ignore: cast_nullable_to_non_nullable
-              as TypeUsageKind,
-      referringElementName: null == referringElementName
-          ? _value.referringElementName
-          : referringElementName // ignore: cast_nullable_to_non_nullable
-              as String,
-      isVisibleForTesting: null == isVisibleForTesting
-          ? _value.isVisibleForTesting
-          : isVisibleForTesting // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is TypeUsage &&
+            (identical(other.kind, kind) || other.kind == kind) &&
+            (identical(other.referringElementName, referringElementName) ||
+                other.referringElementName == referringElementName) &&
+            (identical(other.isVisibleForTesting, isVisibleForTesting) ||
+                other.isVisibleForTesting == isVisibleForTesting));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, kind, referringElementName, isVisibleForTesting);
+
+  @override
+  String toString() {
+    return 'TypeUsage(kind: $kind, referringElementName: $referringElementName, isVisibleForTesting: $isVisibleForTesting)';
   }
 }
 
 /// @nodoc
-abstract class _$$TypeUsageImplCopyWith<$Res>
-    implements $TypeUsageCopyWith<$Res> {
-  factory _$$TypeUsageImplCopyWith(
-          _$TypeUsageImpl value, $Res Function(_$TypeUsageImpl) then) =
-      __$$TypeUsageImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $TypeUsageCopyWith<$Res> {
+  factory $TypeUsageCopyWith(TypeUsage value, $Res Function(TypeUsage) _then) =
+      _$TypeUsageCopyWithImpl;
   @useResult
   $Res call(
       {TypeUsageKind kind,
@@ -94,12 +65,11 @@ abstract class _$$TypeUsageImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$TypeUsageImplCopyWithImpl<$Res>
-    extends _$TypeUsageCopyWithImpl<$Res, _$TypeUsageImpl>
-    implements _$$TypeUsageImplCopyWith<$Res> {
-  __$$TypeUsageImplCopyWithImpl(
-      _$TypeUsageImpl _value, $Res Function(_$TypeUsageImpl) _then)
-      : super(_value, _then);
+class _$TypeUsageCopyWithImpl<$Res> implements $TypeUsageCopyWith<$Res> {
+  _$TypeUsageCopyWithImpl(this._self, this._then);
+
+  final TypeUsage _self;
+  final $Res Function(TypeUsage) _then;
 
   /// Create a copy of TypeUsage
   /// with the given fields replaced by the non-null parameter values.
@@ -110,17 +80,17 @@ class __$$TypeUsageImplCopyWithImpl<$Res>
     Object? referringElementName = null,
     Object? isVisibleForTesting = null,
   }) {
-    return _then(_$TypeUsageImpl(
+    return _then(_self.copyWith(
       kind: null == kind
-          ? _value.kind
+          ? _self.kind
           : kind // ignore: cast_nullable_to_non_nullable
               as TypeUsageKind,
       referringElementName: null == referringElementName
-          ? _value.referringElementName
+          ? _self.referringElementName
           : referringElementName // ignore: cast_nullable_to_non_nullable
               as String,
       isVisibleForTesting: null == isVisibleForTesting
-          ? _value.isVisibleForTesting
+          ? _self.isVisibleForTesting
           : isVisibleForTesting // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
@@ -129,8 +99,8 @@ class __$$TypeUsageImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$TypeUsageImpl extends _TypeUsage {
-  const _$TypeUsageImpl(
+class _TypeUsage extends TypeUsage {
+  const _TypeUsage(
       {required this.kind,
       required this.referringElementName,
       required this.isVisibleForTesting})
@@ -148,16 +118,19 @@ class _$TypeUsageImpl extends _TypeUsage {
   @override
   final bool isVisibleForTesting;
 
+  /// Create a copy of TypeUsage
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'TypeUsage(kind: $kind, referringElementName: $referringElementName, isVisibleForTesting: $isVisibleForTesting)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TypeUsageCopyWith<_TypeUsage> get copyWith =>
+      __$TypeUsageCopyWithImpl<_TypeUsage>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TypeUsageImpl &&
+            other is _TypeUsage &&
             (identical(other.kind, kind) || other.kind == kind) &&
             (identical(other.referringElementName, referringElementName) ||
                 other.referringElementName == referringElementName) &&
@@ -169,38 +142,57 @@ class _$TypeUsageImpl extends _TypeUsage {
   int get hashCode =>
       Object.hash(runtimeType, kind, referringElementName, isVisibleForTesting);
 
+  @override
+  String toString() {
+    return 'TypeUsage(kind: $kind, referringElementName: $referringElementName, isVisibleForTesting: $isVisibleForTesting)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TypeUsageCopyWith<$Res>
+    implements $TypeUsageCopyWith<$Res> {
+  factory _$TypeUsageCopyWith(
+          _TypeUsage value, $Res Function(_TypeUsage) _then) =
+      __$TypeUsageCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {TypeUsageKind kind,
+      String referringElementName,
+      bool isVisibleForTesting});
+}
+
+/// @nodoc
+class __$TypeUsageCopyWithImpl<$Res> implements _$TypeUsageCopyWith<$Res> {
+  __$TypeUsageCopyWithImpl(this._self, this._then);
+
+  final _TypeUsage _self;
+  final $Res Function(_TypeUsage) _then;
+
   /// Create a copy of TypeUsage
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$TypeUsageImplCopyWith<_$TypeUsageImpl> get copyWith =>
-      __$$TypeUsageImplCopyWithImpl<_$TypeUsageImpl>(this, _$identity);
+  $Res call({
+    Object? kind = null,
+    Object? referringElementName = null,
+    Object? isVisibleForTesting = null,
+  }) {
+    return _then(_TypeUsage(
+      kind: null == kind
+          ? _self.kind
+          : kind // ignore: cast_nullable_to_non_nullable
+              as TypeUsageKind,
+      referringElementName: null == referringElementName
+          ? _self.referringElementName
+          : referringElementName // ignore: cast_nullable_to_non_nullable
+              as String,
+      isVisibleForTesting: null == isVisibleForTesting
+          ? _self.isVisibleForTesting
+          : isVisibleForTesting // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _TypeUsage extends TypeUsage {
-  const factory _TypeUsage(
-      {required final TypeUsageKind kind,
-      required final String referringElementName,
-      required final bool isVisibleForTesting}) = _$TypeUsageImpl;
-  const _TypeUsage._() : super._();
-
-  /// kind of usage
-  @override
-  TypeUsageKind get kind;
-
-  /// the name of the referring element
-  @override
-  String get referringElementName;
-
-  /// defines if the usage happened in a visibleForTesting context
-  @override
-  bool get isVisibleForTesting;
-
-  /// Create a copy of TypeUsage
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TypeUsageImplCopyWith<_$TypeUsageImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/src/storage/v3/executable_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.dart
@@ -33,7 +33,7 @@ enum ExecutableTypeStorageV3 {
 }
 
 @freezed
-class ExecutableParameterDeclarationStorageV3
+sealed class ExecutableParameterDeclarationStorageV3
     with _$ExecutableParameterDeclarationStorageV3 {
   const ExecutableParameterDeclarationStorageV3._();
 
@@ -68,7 +68,8 @@ class ExecutableParameterDeclarationStorageV3
 
 /// Represents an executable declaration
 @freezed
-class ExecutableDeclarationStorageV3 with _$ExecutableDeclarationStorageV3 {
+sealed class ExecutableDeclarationStorageV3
+    with _$ExecutableDeclarationStorageV3 {
   const ExecutableDeclarationStorageV3._();
 
   const factory ExecutableDeclarationStorageV3({

--- a/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,232 +10,37 @@ part of 'executable_declaration_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-ExecutableParameterDeclarationStorageV3
-    _$ExecutableParameterDeclarationStorageV3FromJson(
-        Map<String, dynamic> json) {
-  return _ExecutableParameterDeclarationStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$ExecutableParameterDeclarationStorageV3 {
-  bool get isRequired => throw _privateConstructorUsedError;
-  bool get isNamed => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  bool get isDeprecated => throw _privateConstructorUsedError;
-  bool get isExperimental => throw _privateConstructorUsedError;
-  String get typeName => throw _privateConstructorUsedError;
-  String get relativePath => throw _privateConstructorUsedError;
-
-  /// Serializes this ExecutableParameterDeclarationStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  bool get isRequired;
+  bool get isNamed;
+  String get name;
+  bool get isDeprecated;
+  bool get isExperimental;
+  String get typeName;
+  String get relativePath;
 
   /// Create a copy of ExecutableParameterDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $ExecutableParameterDeclarationStorageV3CopyWith<
           ExecutableParameterDeclarationStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
+      get copyWith => _$ExecutableParameterDeclarationStorageV3CopyWithImpl<
+              ExecutableParameterDeclarationStorageV3>(
+          this as ExecutableParameterDeclarationStorageV3, _$identity);
 
-/// @nodoc
-abstract class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
-  factory $ExecutableParameterDeclarationStorageV3CopyWith(
-          ExecutableParameterDeclarationStorageV3 value,
-          $Res Function(ExecutableParameterDeclarationStorageV3) then) =
-      _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-          ExecutableParameterDeclarationStorageV3>;
-  @useResult
-  $Res call(
-      {bool isRequired,
-      bool isNamed,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      String typeName,
-      String relativePath});
-}
-
-/// @nodoc
-class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends ExecutableParameterDeclarationStorageV3>
-    implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
-  _$ExecutableParameterDeclarationStorageV3CopyWithImpl(
-      this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ExecutableParameterDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? typeName = null,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isNamed: null == isNamed
-          ? _value.isNamed
-          : isNamed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<$Res>
-    implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
-  factory _$$ExecutableParameterDeclarationStorageV3ImplCopyWith(
-          _$ExecutableParameterDeclarationStorageV3Impl value,
-          $Res Function(_$ExecutableParameterDeclarationStorageV3Impl) then) =
-      __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {bool isRequired,
-      bool isNamed,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      String typeName,
-      String relativePath});
-}
-
-/// @nodoc
-class __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<$Res>
-    extends _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res,
-        _$ExecutableParameterDeclarationStorageV3Impl>
-    implements _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<$Res> {
-  __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl(
-      _$ExecutableParameterDeclarationStorageV3Impl _value,
-      $Res Function(_$ExecutableParameterDeclarationStorageV3Impl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of ExecutableParameterDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? isRequired = null,
-    Object? isNamed = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? typeName = null,
-    Object? relativePath = null,
-  }) {
-    return _then(_$ExecutableParameterDeclarationStorageV3Impl(
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isNamed: null == isNamed
-          ? _value.isNamed
-          : isNamed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$ExecutableParameterDeclarationStorageV3Impl
-    extends _ExecutableParameterDeclarationStorageV3 {
-  const _$ExecutableParameterDeclarationStorageV3Impl(
-      {required this.isRequired,
-      required this.isNamed,
-      required this.name,
-      required this.isDeprecated,
-      required this.isExperimental,
-      required this.typeName,
-      required this.relativePath})
-      : super._();
-
-  factory _$ExecutableParameterDeclarationStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$ExecutableParameterDeclarationStorageV3ImplFromJson(json);
-
-  @override
-  final bool isRequired;
-  @override
-  final bool isNamed;
-  @override
-  final String name;
-  @override
-  final bool isDeprecated;
-  @override
-  final bool isExperimental;
-  @override
-  final String typeName;
-  @override
-  final String relativePath;
-
-  @override
-  String toString() {
-    return 'ExecutableParameterDeclarationStorageV3(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, relativePath: $relativePath)';
-  }
+  /// Serializes this ExecutableParameterDeclarationStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ExecutableParameterDeclarationStorageV3Impl &&
+            other is ExecutableParameterDeclarationStorageV3 &&
             (identical(other.isRequired, isRequired) ||
                 other.isRequired == isRequired) &&
             (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
@@ -254,275 +60,77 @@ class _$ExecutableParameterDeclarationStorageV3Impl
   int get hashCode => Object.hash(runtimeType, isRequired, isNamed, name,
       isDeprecated, isExperimental, typeName, relativePath);
 
-  /// Create a copy of ExecutableParameterDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<
-          _$ExecutableParameterDeclarationStorageV3Impl>
-      get copyWith =>
-          __$$ExecutableParameterDeclarationStorageV3ImplCopyWithImpl<
-              _$ExecutableParameterDeclarationStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ExecutableParameterDeclarationStorageV3ImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _ExecutableParameterDeclarationStorageV3
-    extends ExecutableParameterDeclarationStorageV3 {
-  const factory _ExecutableParameterDeclarationStorageV3(
-          {required final bool isRequired,
-          required final bool isNamed,
-          required final String name,
-          required final bool isDeprecated,
-          required final bool isExperimental,
-          required final String typeName,
-          required final String relativePath}) =
-      _$ExecutableParameterDeclarationStorageV3Impl;
-  const _ExecutableParameterDeclarationStorageV3._() : super._();
-
-  factory _ExecutableParameterDeclarationStorageV3.fromJson(
-          Map<String, dynamic> json) =
-      _$ExecutableParameterDeclarationStorageV3Impl.fromJson;
-
-  @override
-  bool get isRequired;
-  @override
-  bool get isNamed;
-  @override
-  String get name;
-  @override
-  bool get isDeprecated;
-  @override
-  bool get isExperimental;
-  @override
-  String get typeName;
-  @override
-  String get relativePath;
-
-  /// Create a copy of ExecutableParameterDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ExecutableParameterDeclarationStorageV3ImplCopyWith<
-          _$ExecutableParameterDeclarationStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-ExecutableDeclarationStorageV3 _$ExecutableDeclarationStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _ExecutableDeclarationStorageV3.fromJson(json);
-}
-
-/// @nodoc
-mixin _$ExecutableDeclarationStorageV3 {
-  String get returnTypeName => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  bool get isDeprecated => throw _privateConstructorUsedError;
-  bool get isExperimental => throw _privateConstructorUsedError;
-  List<ExecutableParameterDeclarationStorageV3> get parameters =>
-      throw _privateConstructorUsedError;
-  List<String> get typeParameterNames => throw _privateConstructorUsedError;
-  ExecutableTypeStorageV3 get type => throw _privateConstructorUsedError;
-  bool get isStatic => throw _privateConstructorUsedError;
-  Set<String> get entryPoints => throw _privateConstructorUsedError;
-  String get relativePath => throw _privateConstructorUsedError;
-
-  /// Serializes this ExecutableDeclarationStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of ExecutableDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $ExecutableDeclarationStorageV3CopyWith<ExecutableDeclarationStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ExecutableDeclarationStorageV3CopyWith<$Res> {
-  factory $ExecutableDeclarationStorageV3CopyWith(
-          ExecutableDeclarationStorageV3 value,
-          $Res Function(ExecutableDeclarationStorageV3) then) =
-      _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-          ExecutableDeclarationStorageV3>;
-  @useResult
-  $Res call(
-      {String returnTypeName,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      List<ExecutableParameterDeclarationStorageV3> parameters,
-      List<String> typeParameterNames,
-      ExecutableTypeStorageV3 type,
-      bool isStatic,
-      Set<String> entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends ExecutableDeclarationStorageV3>
-    implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
-  _$ExecutableDeclarationStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ExecutableDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? returnTypeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      returnTypeName: null == returnTypeName
-          ? _value.returnTypeName
-          : returnTypeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      parameters: null == parameters
-          ? _value.parameters
-          : parameters // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: null == typeParameterNames
-          ? _value.typeParameterNames
-          : typeParameterNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as ExecutableTypeStorageV3,
-      isStatic: null == isStatic
-          ? _value.isStatic
-          : isStatic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: null == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  String toString() {
+    return 'ExecutableParameterDeclarationStorageV3(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$ExecutableDeclarationStorageV3ImplCopyWith<$Res>
-    implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
-  factory _$$ExecutableDeclarationStorageV3ImplCopyWith(
-          _$ExecutableDeclarationStorageV3Impl value,
-          $Res Function(_$ExecutableDeclarationStorageV3Impl) then) =
-      __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
+  factory $ExecutableParameterDeclarationStorageV3CopyWith(
+          ExecutableParameterDeclarationStorageV3 value,
+          $Res Function(ExecutableParameterDeclarationStorageV3) _then) =
+      _$ExecutableParameterDeclarationStorageV3CopyWithImpl;
   @useResult
   $Res call(
-      {String returnTypeName,
+      {bool isRequired,
+      bool isNamed,
       String name,
       bool isDeprecated,
       bool isExperimental,
-      List<ExecutableParameterDeclarationStorageV3> parameters,
-      List<String> typeParameterNames,
-      ExecutableTypeStorageV3 type,
-      bool isStatic,
-      Set<String> entryPoints,
+      String typeName,
       String relativePath});
 }
 
 /// @nodoc
-class __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<$Res>
-    extends _$ExecutableDeclarationStorageV3CopyWithImpl<$Res,
-        _$ExecutableDeclarationStorageV3Impl>
-    implements _$$ExecutableDeclarationStorageV3ImplCopyWith<$Res> {
-  __$$ExecutableDeclarationStorageV3ImplCopyWithImpl(
-      _$ExecutableDeclarationStorageV3Impl _value,
-      $Res Function(_$ExecutableDeclarationStorageV3Impl) _then)
-      : super(_value, _then);
+class _$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
+    implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
+  _$ExecutableParameterDeclarationStorageV3CopyWithImpl(this._self, this._then);
 
-  /// Create a copy of ExecutableDeclarationStorageV3
+  final ExecutableParameterDeclarationStorageV3 _self;
+  final $Res Function(ExecutableParameterDeclarationStorageV3) _then;
+
+  /// Create a copy of ExecutableParameterDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? returnTypeName = null,
+    Object? isRequired = null,
+    Object? isNamed = null,
     Object? name = null,
     Object? isDeprecated = null,
     Object? isExperimental = null,
-    Object? parameters = null,
-    Object? typeParameterNames = null,
-    Object? type = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
+    Object? typeName = null,
     Object? relativePath = null,
   }) {
-    return _then(_$ExecutableDeclarationStorageV3Impl(
-      returnTypeName: null == returnTypeName
-          ? _value.returnTypeName
-          : returnTypeName // ignore: cast_nullable_to_non_nullable
-              as String,
+    return _then(_self.copyWith(
+      isRequired: null == isRequired
+          ? _self.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isNamed: null == isNamed
+          ? _self.isNamed
+          : isNamed // ignore: cast_nullable_to_non_nullable
+              as bool,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
-      parameters: null == parameters
-          ? _value._parameters
-          : parameters // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableParameterDeclarationStorageV3>,
-      typeParameterNames: null == typeParameterNames
-          ? _value._typeParameterNames
-          : typeParameterNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as ExecutableTypeStorageV3,
-      isStatic: null == isStatic
-          ? _value.isStatic
-          : isStatic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: null == entryPoints
-          ? _value._entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -531,9 +139,321 @@ class __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$ExecutableDeclarationStorageV3Impl
-    extends _ExecutableDeclarationStorageV3 {
-  const _$ExecutableDeclarationStorageV3Impl(
+class _ExecutableParameterDeclarationStorageV3
+    extends ExecutableParameterDeclarationStorageV3 {
+  const _ExecutableParameterDeclarationStorageV3(
+      {required this.isRequired,
+      required this.isNamed,
+      required this.name,
+      required this.isDeprecated,
+      required this.isExperimental,
+      required this.typeName,
+      required this.relativePath})
+      : super._();
+  factory _ExecutableParameterDeclarationStorageV3.fromJson(
+          Map<String, dynamic> json) =>
+      _$ExecutableParameterDeclarationStorageV3FromJson(json);
+
+  @override
+  final bool isRequired;
+  @override
+  final bool isNamed;
+  @override
+  final String name;
+  @override
+  final bool isDeprecated;
+  @override
+  final bool isExperimental;
+  @override
+  final String typeName;
+  @override
+  final String relativePath;
+
+  /// Create a copy of ExecutableParameterDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExecutableParameterDeclarationStorageV3CopyWith<
+          _ExecutableParameterDeclarationStorageV3>
+      get copyWith => __$ExecutableParameterDeclarationStorageV3CopyWithImpl<
+          _ExecutableParameterDeclarationStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ExecutableParameterDeclarationStorageV3ToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ExecutableParameterDeclarationStorageV3 &&
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
+            (identical(other.isNamed, isNamed) || other.isNamed == isNamed) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, isRequired, isNamed, name,
+      isDeprecated, isExperimental, typeName, relativePath);
+
+  @override
+  String toString() {
+    return 'ExecutableParameterDeclarationStorageV3(isRequired: $isRequired, isNamed: $isNamed, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, typeName: $typeName, relativePath: $relativePath)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ExecutableParameterDeclarationStorageV3CopyWith<$Res>
+    implements $ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
+  factory _$ExecutableParameterDeclarationStorageV3CopyWith(
+          _ExecutableParameterDeclarationStorageV3 value,
+          $Res Function(_ExecutableParameterDeclarationStorageV3) _then) =
+      __$ExecutableParameterDeclarationStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {bool isRequired,
+      bool isNamed,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      String typeName,
+      String relativePath});
+}
+
+/// @nodoc
+class __$ExecutableParameterDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$ExecutableParameterDeclarationStorageV3CopyWith<$Res> {
+  __$ExecutableParameterDeclarationStorageV3CopyWithImpl(
+      this._self, this._then);
+
+  final _ExecutableParameterDeclarationStorageV3 _self;
+  final $Res Function(_ExecutableParameterDeclarationStorageV3) _then;
+
+  /// Create a copy of ExecutableParameterDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? isRequired = null,
+    Object? isNamed = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? typeName = null,
+    Object? relativePath = null,
+  }) {
+    return _then(_ExecutableParameterDeclarationStorageV3(
+      isRequired: null == isRequired
+          ? _self.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isNamed: null == isNamed
+          ? _self.isNamed
+          : isNamed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$ExecutableDeclarationStorageV3 {
+  String get returnTypeName;
+  String get name;
+  bool get isDeprecated;
+  bool get isExperimental;
+  List<ExecutableParameterDeclarationStorageV3> get parameters;
+  List<String> get typeParameterNames;
+  ExecutableTypeStorageV3 get type;
+  bool get isStatic;
+  Set<String> get entryPoints;
+  String get relativePath;
+
+  /// Create a copy of ExecutableDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $ExecutableDeclarationStorageV3CopyWith<ExecutableDeclarationStorageV3>
+      get copyWith => _$ExecutableDeclarationStorageV3CopyWithImpl<
+              ExecutableDeclarationStorageV3>(
+          this as ExecutableDeclarationStorageV3, _$identity);
+
+  /// Serializes this ExecutableDeclarationStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ExecutableDeclarationStorageV3 &&
+            (identical(other.returnTypeName, returnTypeName) ||
+                other.returnTypeName == returnTypeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            const DeepCollectionEquality()
+                .equals(other.parameters, parameters) &&
+            const DeepCollectionEquality()
+                .equals(other.typeParameterNames, typeParameterNames) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      returnTypeName,
+      name,
+      isDeprecated,
+      isExperimental,
+      const DeepCollectionEquality().hash(parameters),
+      const DeepCollectionEquality().hash(typeParameterNames),
+      type,
+      isStatic,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'ExecutableDeclarationStorageV3(returnTypeName: $returnTypeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ExecutableDeclarationStorageV3CopyWith<$Res> {
+  factory $ExecutableDeclarationStorageV3CopyWith(
+          ExecutableDeclarationStorageV3 value,
+          $Res Function(ExecutableDeclarationStorageV3) _then) =
+      _$ExecutableDeclarationStorageV3CopyWithImpl;
+  @useResult
+  $Res call(
+      {String returnTypeName,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      List<ExecutableParameterDeclarationStorageV3> parameters,
+      List<String> typeParameterNames,
+      ExecutableTypeStorageV3 type,
+      bool isStatic,
+      Set<String> entryPoints,
+      String relativePath});
+}
+
+/// @nodoc
+class _$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
+    implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
+  _$ExecutableDeclarationStorageV3CopyWithImpl(this._self, this._then);
+
+  final ExecutableDeclarationStorageV3 _self;
+  final $Res Function(ExecutableDeclarationStorageV3) _then;
+
+  /// Create a copy of ExecutableDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
+    Object? relativePath = null,
+  }) {
+    return _then(_self.copyWith(
+      returnTypeName: null == returnTypeName
+          ? _self.returnTypeName
+          : returnTypeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      parameters: null == parameters
+          ? _self.parameters
+          : parameters // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableParameterDeclarationStorageV3>,
+      typeParameterNames: null == typeParameterNames
+          ? _self.typeParameterNames
+          : typeParameterNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ExecutableTypeStorageV3,
+      isStatic: null == isStatic
+          ? _self.isStatic
+          : isStatic // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: null == entryPoints
+          ? _self.entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _ExecutableDeclarationStorageV3 extends ExecutableDeclarationStorageV3 {
+  const _ExecutableDeclarationStorageV3(
       {required this.returnTypeName,
       required this.name,
       required this.isDeprecated,
@@ -548,10 +468,8 @@ class _$ExecutableDeclarationStorageV3Impl
         _typeParameterNames = typeParameterNames,
         _entryPoints = entryPoints,
         super._();
-
-  factory _$ExecutableDeclarationStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$ExecutableDeclarationStorageV3ImplFromJson(json);
+  factory _ExecutableDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$ExecutableDeclarationStorageV3FromJson(json);
 
   @override
   final String returnTypeName;
@@ -593,16 +511,27 @@ class _$ExecutableDeclarationStorageV3Impl
   @override
   final String relativePath;
 
+  /// Create a copy of ExecutableDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'ExecutableDeclarationStorageV3(returnTypeName: $returnTypeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ExecutableDeclarationStorageV3CopyWith<_ExecutableDeclarationStorageV3>
+      get copyWith => __$ExecutableDeclarationStorageV3CopyWithImpl<
+          _ExecutableDeclarationStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$ExecutableDeclarationStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ExecutableDeclarationStorageV3Impl &&
+            other is _ExecutableDeclarationStorageV3 &&
             (identical(other.returnTypeName, returnTypeName) ||
                 other.returnTypeName == returnTypeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -638,69 +567,101 @@ class _$ExecutableDeclarationStorageV3Impl
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
-  /// Create a copy of ExecutableDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$ExecutableDeclarationStorageV3ImplCopyWith<
-          _$ExecutableDeclarationStorageV3Impl>
-      get copyWith => __$$ExecutableDeclarationStorageV3ImplCopyWithImpl<
-          _$ExecutableDeclarationStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$ExecutableDeclarationStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'ExecutableDeclarationStorageV3(returnTypeName: $returnTypeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, parameters: $parameters, typeParameterNames: $typeParameterNames, type: $type, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
-abstract class _ExecutableDeclarationStorageV3
-    extends ExecutableDeclarationStorageV3 {
-  const factory _ExecutableDeclarationStorageV3(
-      {required final String returnTypeName,
-      required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final List<ExecutableParameterDeclarationStorageV3> parameters,
-      required final List<String> typeParameterNames,
-      required final ExecutableTypeStorageV3 type,
-      required final bool isStatic,
-      required final Set<String> entryPoints,
-      required final String
-          relativePath}) = _$ExecutableDeclarationStorageV3Impl;
-  const _ExecutableDeclarationStorageV3._() : super._();
+/// @nodoc
+abstract mixin class _$ExecutableDeclarationStorageV3CopyWith<$Res>
+    implements $ExecutableDeclarationStorageV3CopyWith<$Res> {
+  factory _$ExecutableDeclarationStorageV3CopyWith(
+          _ExecutableDeclarationStorageV3 value,
+          $Res Function(_ExecutableDeclarationStorageV3) _then) =
+      __$ExecutableDeclarationStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String returnTypeName,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      List<ExecutableParameterDeclarationStorageV3> parameters,
+      List<String> typeParameterNames,
+      ExecutableTypeStorageV3 type,
+      bool isStatic,
+      Set<String> entryPoints,
+      String relativePath});
+}
 
-  factory _ExecutableDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$ExecutableDeclarationStorageV3Impl.fromJson;
+/// @nodoc
+class __$ExecutableDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$ExecutableDeclarationStorageV3CopyWith<$Res> {
+  __$ExecutableDeclarationStorageV3CopyWithImpl(this._self, this._then);
 
-  @override
-  String get returnTypeName;
-  @override
-  String get name;
-  @override
-  bool get isDeprecated;
-  @override
-  bool get isExperimental;
-  @override
-  List<ExecutableParameterDeclarationStorageV3> get parameters;
-  @override
-  List<String> get typeParameterNames;
-  @override
-  ExecutableTypeStorageV3 get type;
-  @override
-  bool get isStatic;
-  @override
-  Set<String> get entryPoints;
-  @override
-  String get relativePath;
+  final _ExecutableDeclarationStorageV3 _self;
+  final $Res Function(_ExecutableDeclarationStorageV3) _then;
 
   /// Create a copy of ExecutableDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ExecutableDeclarationStorageV3ImplCopyWith<
-          _$ExecutableDeclarationStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? returnTypeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? parameters = null,
+    Object? typeParameterNames = null,
+    Object? type = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
+    Object? relativePath = null,
+  }) {
+    return _then(_ExecutableDeclarationStorageV3(
+      returnTypeName: null == returnTypeName
+          ? _self.returnTypeName
+          : returnTypeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      parameters: null == parameters
+          ? _self._parameters
+          : parameters // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableParameterDeclarationStorageV3>,
+      typeParameterNames: null == typeParameterNames
+          ? _self._typeParameterNames
+          : typeParameterNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      type: null == type
+          ? _self.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as ExecutableTypeStorageV3,
+      isStatic: null == isStatic
+          ? _self.isStatic
+          : isStatic // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: null == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/storage/v3/executable_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/executable_declaration_storage_v3.g.dart
@@ -8,10 +8,10 @@ part of 'executable_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$ExecutableParameterDeclarationStorageV3Impl
-    _$$ExecutableParameterDeclarationStorageV3ImplFromJson(
+_ExecutableParameterDeclarationStorageV3
+    _$ExecutableParameterDeclarationStorageV3FromJson(
             Map<String, dynamic> json) =>
-        _$ExecutableParameterDeclarationStorageV3Impl(
+        _ExecutableParameterDeclarationStorageV3(
           isRequired: json['isRequired'] as bool,
           isNamed: json['isNamed'] as bool,
           name: json['name'] as String,
@@ -21,8 +21,8 @@ _$ExecutableParameterDeclarationStorageV3Impl
           relativePath: json['relativePath'] as String,
         );
 
-Map<String, dynamic> _$$ExecutableParameterDeclarationStorageV3ImplToJson(
-        _$ExecutableParameterDeclarationStorageV3Impl instance) =>
+Map<String, dynamic> _$ExecutableParameterDeclarationStorageV3ToJson(
+        _ExecutableParameterDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'isRequired': instance.isRequired,
       'isNamed': instance.isNamed,
@@ -33,30 +33,30 @@ Map<String, dynamic> _$$ExecutableParameterDeclarationStorageV3ImplToJson(
       'relativePath': instance.relativePath,
     };
 
-_$ExecutableDeclarationStorageV3Impl
-    _$$ExecutableDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
-        _$ExecutableDeclarationStorageV3Impl(
-          returnTypeName: json['returnTypeName'] as String,
-          name: json['name'] as String,
-          isDeprecated: json['isDeprecated'] as bool,
-          isExperimental: json['isExperimental'] as bool,
-          parameters: (json['parameters'] as List<dynamic>)
-              .map((e) => ExecutableParameterDeclarationStorageV3.fromJson(
-                  e as Map<String, dynamic>))
-              .toList(),
-          typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
-              .map((e) => e as String)
-              .toList(),
-          type: $enumDecode(_$ExecutableTypeStorageV3EnumMap, json['type']),
-          isStatic: json['isStatic'] as bool,
-          entryPoints: (json['entryPoints'] as List<dynamic>)
-              .map((e) => e as String)
-              .toSet(),
-          relativePath: json['relativePath'] as String,
-        );
+_ExecutableDeclarationStorageV3 _$ExecutableDeclarationStorageV3FromJson(
+        Map<String, dynamic> json) =>
+    _ExecutableDeclarationStorageV3(
+      returnTypeName: json['returnTypeName'] as String,
+      name: json['name'] as String,
+      isDeprecated: json['isDeprecated'] as bool,
+      isExperimental: json['isExperimental'] as bool,
+      parameters: (json['parameters'] as List<dynamic>)
+          .map((e) => ExecutableParameterDeclarationStorageV3.fromJson(
+              e as Map<String, dynamic>))
+          .toList(),
+      typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      type: $enumDecode(_$ExecutableTypeStorageV3EnumMap, json['type']),
+      isStatic: json['isStatic'] as bool,
+      entryPoints: (json['entryPoints'] as List<dynamic>)
+          .map((e) => e as String)
+          .toSet(),
+      relativePath: json['relativePath'] as String,
+    );
 
-Map<String, dynamic> _$$ExecutableDeclarationStorageV3ImplToJson(
-        _$ExecutableDeclarationStorageV3Impl instance) =>
+Map<String, dynamic> _$ExecutableDeclarationStorageV3ToJson(
+        _ExecutableDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'returnTypeName': instance.returnTypeName,
       'name': instance.name,

--- a/lib/src/storage/v3/field_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.dart
@@ -7,7 +7,7 @@ part 'field_declaration_storage_v3.g.dart';
 
 /// represents a found FieldDeclaration
 @freezed
-class FieldDeclarationStorageV3 with _$FieldDeclarationStorageV3 {
+sealed class FieldDeclarationStorageV3 with _$FieldDeclarationStorageV3 {
   const FieldDeclarationStorageV3._();
 
   const factory FieldDeclarationStorageV3({

--- a/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,131 +10,81 @@ part of 'field_declaration_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-FieldDeclarationStorageV3 _$FieldDeclarationStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _FieldDeclarationStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$FieldDeclarationStorageV3 {
-  String get typeName => throw _privateConstructorUsedError;
-  String get name => throw _privateConstructorUsedError;
-  bool get isDeprecated => throw _privateConstructorUsedError;
-  bool get isExperimental => throw _privateConstructorUsedError;
-  bool get isStatic => throw _privateConstructorUsedError;
-  Set<String> get entryPoints => throw _privateConstructorUsedError;
-  String get relativePath => throw _privateConstructorUsedError;
-  bool get isReadable => throw _privateConstructorUsedError;
-  bool get isWriteable => throw _privateConstructorUsedError;
-
-  /// Serializes this FieldDeclarationStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get typeName;
+  String get name;
+  bool get isDeprecated;
+  bool get isExperimental;
+  bool get isStatic;
+  Set<String> get entryPoints;
+  String get relativePath;
+  bool get isReadable;
+  bool get isWriteable;
 
   /// Create a copy of FieldDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $FieldDeclarationStorageV3CopyWith<FieldDeclarationStorageV3> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $FieldDeclarationStorageV3CopyWith<$Res> {
-  factory $FieldDeclarationStorageV3CopyWith(FieldDeclarationStorageV3 value,
-          $Res Function(FieldDeclarationStorageV3) then) =
-      _$FieldDeclarationStorageV3CopyWithImpl<$Res, FieldDeclarationStorageV3>;
-  @useResult
-  $Res call(
-      {String typeName,
-      String name,
-      bool isDeprecated,
-      bool isExperimental,
-      bool isStatic,
-      Set<String> entryPoints,
-      String relativePath,
-      bool isReadable,
-      bool isWriteable});
-}
-
-/// @nodoc
-class _$FieldDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends FieldDeclarationStorageV3>
-    implements $FieldDeclarationStorageV3CopyWith<$Res> {
-  _$FieldDeclarationStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of FieldDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $FieldDeclarationStorageV3CopyWith<FieldDeclarationStorageV3> get copyWith =>
+      _$FieldDeclarationStorageV3CopyWithImpl<FieldDeclarationStorageV3>(
+          this as FieldDeclarationStorageV3, _$identity);
+
+  /// Serializes this FieldDeclarationStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? typeName = null,
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? isStatic = null,
-    Object? entryPoints = null,
-    Object? relativePath = null,
-    Object? isReadable = null,
-    Object? isWriteable = null,
-  }) {
-    return _then(_value.copyWith(
-      typeName: null == typeName
-          ? _value.typeName
-          : typeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isStatic: null == isStatic
-          ? _value.isStatic
-          : isStatic // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: null == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      isReadable: null == isReadable
-          ? _value.isReadable
-          : isReadable // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isWriteable: null == isWriteable
-          ? _value.isWriteable
-          : isWriteable // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is FieldDeclarationStorageV3 &&
+            (identical(other.typeName, typeName) ||
+                other.typeName == typeName) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            (identical(other.isStatic, isStatic) ||
+                other.isStatic == isStatic) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath) &&
+            (identical(other.isReadable, isReadable) ||
+                other.isReadable == isReadable) &&
+            (identical(other.isWriteable, isWriteable) ||
+                other.isWriteable == isWriteable));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      typeName,
+      name,
+      isDeprecated,
+      isExperimental,
+      isStatic,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath,
+      isReadable,
+      isWriteable);
+
+  @override
+  String toString() {
+    return 'FieldDeclarationStorageV3(typeName: $typeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
   }
 }
 
 /// @nodoc
-abstract class _$$FieldDeclarationStorageV3ImplCopyWith<$Res>
-    implements $FieldDeclarationStorageV3CopyWith<$Res> {
-  factory _$$FieldDeclarationStorageV3ImplCopyWith(
-          _$FieldDeclarationStorageV3Impl value,
-          $Res Function(_$FieldDeclarationStorageV3Impl) then) =
-      __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $FieldDeclarationStorageV3CopyWith<$Res> {
+  factory $FieldDeclarationStorageV3CopyWith(FieldDeclarationStorageV3 value,
+          $Res Function(FieldDeclarationStorageV3) _then) =
+      _$FieldDeclarationStorageV3CopyWithImpl;
   @useResult
   $Res call(
       {String typeName,
@@ -148,14 +99,12 @@ abstract class _$$FieldDeclarationStorageV3ImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>
-    extends _$FieldDeclarationStorageV3CopyWithImpl<$Res,
-        _$FieldDeclarationStorageV3Impl>
-    implements _$$FieldDeclarationStorageV3ImplCopyWith<$Res> {
-  __$$FieldDeclarationStorageV3ImplCopyWithImpl(
-      _$FieldDeclarationStorageV3Impl _value,
-      $Res Function(_$FieldDeclarationStorageV3Impl) _then)
-      : super(_value, _then);
+class _$FieldDeclarationStorageV3CopyWithImpl<$Res>
+    implements $FieldDeclarationStorageV3CopyWith<$Res> {
+  _$FieldDeclarationStorageV3CopyWithImpl(this._self, this._then);
+
+  final FieldDeclarationStorageV3 _self;
+  final $Res Function(FieldDeclarationStorageV3) _then;
 
   /// Create a copy of FieldDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
@@ -172,41 +121,41 @@ class __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>
     Object? isReadable = null,
     Object? isWriteable = null,
   }) {
-    return _then(_$FieldDeclarationStorageV3Impl(
+    return _then(_self.copyWith(
       typeName: null == typeName
-          ? _value.typeName
+          ? _self.typeName
           : typeName // ignore: cast_nullable_to_non_nullable
               as String,
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       isStatic: null == isStatic
-          ? _value.isStatic
+          ? _self.isStatic
           : isStatic // ignore: cast_nullable_to_non_nullable
               as bool,
       entryPoints: null == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
       isReadable: null == isReadable
-          ? _value.isReadable
+          ? _self.isReadable
           : isReadable // ignore: cast_nullable_to_non_nullable
               as bool,
       isWriteable: null == isWriteable
-          ? _value.isWriteable
+          ? _self.isWriteable
           : isWriteable // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
@@ -215,8 +164,8 @@ class __$$FieldDeclarationStorageV3ImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$FieldDeclarationStorageV3Impl extends _FieldDeclarationStorageV3 {
-  const _$FieldDeclarationStorageV3Impl(
+class _FieldDeclarationStorageV3 extends FieldDeclarationStorageV3 {
+  const _FieldDeclarationStorageV3(
       {required this.typeName,
       required this.name,
       required this.isDeprecated,
@@ -228,9 +177,8 @@ class _$FieldDeclarationStorageV3Impl extends _FieldDeclarationStorageV3 {
       required this.isWriteable})
       : _entryPoints = entryPoints,
         super._();
-
-  factory _$FieldDeclarationStorageV3Impl.fromJson(Map<String, dynamic> json) =>
-      _$$FieldDeclarationStorageV3ImplFromJson(json);
+  factory _FieldDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$FieldDeclarationStorageV3FromJson(json);
 
   @override
   final String typeName;
@@ -257,16 +205,28 @@ class _$FieldDeclarationStorageV3Impl extends _FieldDeclarationStorageV3 {
   @override
   final bool isWriteable;
 
+  /// Create a copy of FieldDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'FieldDeclarationStorageV3(typeName: $typeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$FieldDeclarationStorageV3CopyWith<_FieldDeclarationStorageV3>
+      get copyWith =>
+          __$FieldDeclarationStorageV3CopyWithImpl<_FieldDeclarationStorageV3>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$FieldDeclarationStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$FieldDeclarationStorageV3Impl &&
+            other is _FieldDeclarationStorageV3 &&
             (identical(other.typeName, typeName) ||
                 other.typeName == typeName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -300,62 +260,94 @@ class _$FieldDeclarationStorageV3Impl extends _FieldDeclarationStorageV3 {
       isReadable,
       isWriteable);
 
-  /// Create a copy of FieldDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$FieldDeclarationStorageV3ImplCopyWith<_$FieldDeclarationStorageV3Impl>
-      get copyWith => __$$FieldDeclarationStorageV3ImplCopyWithImpl<
-          _$FieldDeclarationStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FieldDeclarationStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'FieldDeclarationStorageV3(typeName: $typeName, name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isStatic: $isStatic, entryPoints: $entryPoints, relativePath: $relativePath, isReadable: $isReadable, isWriteable: $isWriteable)';
   }
 }
 
-abstract class _FieldDeclarationStorageV3 extends FieldDeclarationStorageV3 {
-  const factory _FieldDeclarationStorageV3(
-      {required final String typeName,
-      required final String name,
-      required final bool isDeprecated,
-      required final bool isExperimental,
-      required final bool isStatic,
-      required final Set<String> entryPoints,
-      required final String relativePath,
-      required final bool isReadable,
-      required final bool isWriteable}) = _$FieldDeclarationStorageV3Impl;
-  const _FieldDeclarationStorageV3._() : super._();
+/// @nodoc
+abstract mixin class _$FieldDeclarationStorageV3CopyWith<$Res>
+    implements $FieldDeclarationStorageV3CopyWith<$Res> {
+  factory _$FieldDeclarationStorageV3CopyWith(_FieldDeclarationStorageV3 value,
+          $Res Function(_FieldDeclarationStorageV3) _then) =
+      __$FieldDeclarationStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String typeName,
+      String name,
+      bool isDeprecated,
+      bool isExperimental,
+      bool isStatic,
+      Set<String> entryPoints,
+      String relativePath,
+      bool isReadable,
+      bool isWriteable});
+}
 
-  factory _FieldDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$FieldDeclarationStorageV3Impl.fromJson;
+/// @nodoc
+class __$FieldDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$FieldDeclarationStorageV3CopyWith<$Res> {
+  __$FieldDeclarationStorageV3CopyWithImpl(this._self, this._then);
 
-  @override
-  String get typeName;
-  @override
-  String get name;
-  @override
-  bool get isDeprecated;
-  @override
-  bool get isExperimental;
-  @override
-  bool get isStatic;
-  @override
-  Set<String> get entryPoints;
-  @override
-  String get relativePath;
-  @override
-  bool get isReadable;
-  @override
-  bool get isWriteable;
+  final _FieldDeclarationStorageV3 _self;
+  final $Res Function(_FieldDeclarationStorageV3) _then;
 
   /// Create a copy of FieldDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$FieldDeclarationStorageV3ImplCopyWith<_$FieldDeclarationStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? typeName = null,
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? isStatic = null,
+    Object? entryPoints = null,
+    Object? relativePath = null,
+    Object? isReadable = null,
+    Object? isWriteable = null,
+  }) {
+    return _then(_FieldDeclarationStorageV3(
+      typeName: null == typeName
+          ? _self.typeName
+          : typeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isStatic: null == isStatic
+          ? _self.isStatic
+          : isStatic // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: null == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      isReadable: null == isReadable
+          ? _self.isReadable
+          : isReadable // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isWriteable: null == isWriteable
+          ? _self.isWriteable
+          : isWriteable // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/storage/v3/field_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/field_declaration_storage_v3.g.dart
@@ -8,9 +8,9 @@ part of 'field_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$FieldDeclarationStorageV3Impl _$$FieldDeclarationStorageV3ImplFromJson(
+_FieldDeclarationStorageV3 _$FieldDeclarationStorageV3FromJson(
         Map<String, dynamic> json) =>
-    _$FieldDeclarationStorageV3Impl(
+    _FieldDeclarationStorageV3(
       typeName: json['typeName'] as String,
       name: json['name'] as String,
       isDeprecated: json['isDeprecated'] as bool,
@@ -24,8 +24,8 @@ _$FieldDeclarationStorageV3Impl _$$FieldDeclarationStorageV3ImplFromJson(
       isWriteable: json['isWriteable'] as bool,
     );
 
-Map<String, dynamic> _$$FieldDeclarationStorageV3ImplToJson(
-        _$FieldDeclarationStorageV3Impl instance) =>
+Map<String, dynamic> _$FieldDeclarationStorageV3ToJson(
+        _FieldDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'typeName': instance.typeName,
       'name': instance.name,

--- a/lib/src/storage/v3/interface_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.dart
@@ -11,7 +11,8 @@ part 'interface_declaration_storage_v3.g.dart';
 
 /// Represents a found class declaration
 @freezed
-class InterfaceDeclarationStorageV3 with _$InterfaceDeclarationStorageV3 {
+sealed class InterfaceDeclarationStorageV3
+    with _$InterfaceDeclarationStorageV3 {
   const InterfaceDeclarationStorageV3._();
 
   const factory InterfaceDeclarationStorageV3({

--- a/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,149 +10,91 @@ part of 'interface_declaration_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-InterfaceDeclarationStorageV3 _$InterfaceDeclarationStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _InterfaceDeclarationStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$InterfaceDeclarationStorageV3 {
-  String get name => throw _privateConstructorUsedError;
-  bool get isDeprecated => throw _privateConstructorUsedError;
-  bool get isExperimental => throw _privateConstructorUsedError;
-  bool get isSealed => throw _privateConstructorUsedError;
-  bool get isRequired => throw _privateConstructorUsedError;
-  List<String> get typeParameterNames => throw _privateConstructorUsedError;
-  List<String> get superTypeNames => throw _privateConstructorUsedError;
-  List<ExecutableDeclarationStorageV3> get executableDeclarations =>
-      throw _privateConstructorUsedError;
-  List<FieldDeclarationStorageV3> get fieldDeclarations =>
-      throw _privateConstructorUsedError;
-  Set<String> get entryPoints => throw _privateConstructorUsedError;
-  String get relativePath => throw _privateConstructorUsedError;
-
-  /// Serializes this InterfaceDeclarationStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get name;
+  bool get isDeprecated;
+  bool get isExperimental;
+  bool get isSealed;
+  bool get isRequired;
+  List<String> get typeParameterNames;
+  List<String> get superTypeNames;
+  List<ExecutableDeclarationStorageV3> get executableDeclarations;
+  List<FieldDeclarationStorageV3> get fieldDeclarations;
+  Set<String> get entryPoints;
+  String get relativePath;
 
   /// Create a copy of InterfaceDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $InterfaceDeclarationStorageV3CopyWith<InterfaceDeclarationStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $InterfaceDeclarationStorageV3CopyWith<$Res> {
-  factory $InterfaceDeclarationStorageV3CopyWith(
-          InterfaceDeclarationStorageV3 value,
-          $Res Function(InterfaceDeclarationStorageV3) then) =
-      _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
-          InterfaceDeclarationStorageV3>;
-  @useResult
-  $Res call(
-      {String name,
-      bool isDeprecated,
-      bool isExperimental,
-      bool isSealed,
-      bool isRequired,
-      List<String> typeParameterNames,
-      List<String> superTypeNames,
-      List<ExecutableDeclarationStorageV3> executableDeclarations,
-      List<FieldDeclarationStorageV3> fieldDeclarations,
-      Set<String> entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends InterfaceDeclarationStorageV3>
-    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
-  _$InterfaceDeclarationStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of InterfaceDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $InterfaceDeclarationStorageV3CopyWith<InterfaceDeclarationStorageV3>
+      get copyWith => _$InterfaceDeclarationStorageV3CopyWithImpl<
+              InterfaceDeclarationStorageV3>(
+          this as InterfaceDeclarationStorageV3, _$identity);
+
+  /// Serializes this InterfaceDeclarationStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? name = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? isSealed = null,
-    Object? isRequired = null,
-    Object? typeParameterNames = null,
-    Object? superTypeNames = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? entryPoints = null,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isSealed: null == isSealed
-          ? _value.isSealed
-          : isSealed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isRequired: null == isRequired
-          ? _value.isRequired
-          : isRequired // ignore: cast_nullable_to_non_nullable
-              as bool,
-      typeParameterNames: null == typeParameterNames
-          ? _value.typeParameterNames
-          : typeParameterNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      superTypeNames: null == superTypeNames
-          ? _value.superTypeNames
-          : superTypeNames // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      executableDeclarations: null == executableDeclarations
-          ? _value.executableDeclarations
-          : executableDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
-          ? _value.fieldDeclarations
-          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<FieldDeclarationStorageV3>,
-      entryPoints: null == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InterfaceDeclarationStorageV3 &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            (identical(other.isSealed, isSealed) ||
+                other.isSealed == isSealed) &&
+            (identical(other.isRequired, isRequired) ||
+                other.isRequired == isRequired) &&
+            const DeepCollectionEquality()
+                .equals(other.typeParameterNames, typeParameterNames) &&
+            const DeepCollectionEquality()
+                .equals(other.superTypeNames, superTypeNames) &&
+            const DeepCollectionEquality()
+                .equals(other.executableDeclarations, executableDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.fieldDeclarations, fieldDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      isDeprecated,
+      isExperimental,
+      isSealed,
+      isRequired,
+      const DeepCollectionEquality().hash(typeParameterNames),
+      const DeepCollectionEquality().hash(superTypeNames),
+      const DeepCollectionEquality().hash(executableDeclarations),
+      const DeepCollectionEquality().hash(fieldDeclarations),
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$InterfaceDeclarationStorageV3ImplCopyWith<$Res>
-    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
-  factory _$$InterfaceDeclarationStorageV3ImplCopyWith(
-          _$InterfaceDeclarationStorageV3Impl value,
-          $Res Function(_$InterfaceDeclarationStorageV3Impl) then) =
-      __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  factory $InterfaceDeclarationStorageV3CopyWith(
+          InterfaceDeclarationStorageV3 value,
+          $Res Function(InterfaceDeclarationStorageV3) _then) =
+      _$InterfaceDeclarationStorageV3CopyWithImpl;
   @useResult
   $Res call(
       {String name,
@@ -168,14 +111,12 @@ abstract class _$$InterfaceDeclarationStorageV3ImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>
-    extends _$InterfaceDeclarationStorageV3CopyWithImpl<$Res,
-        _$InterfaceDeclarationStorageV3Impl>
-    implements _$$InterfaceDeclarationStorageV3ImplCopyWith<$Res> {
-  __$$InterfaceDeclarationStorageV3ImplCopyWithImpl(
-      _$InterfaceDeclarationStorageV3Impl _value,
-      $Res Function(_$InterfaceDeclarationStorageV3Impl) _then)
-      : super(_value, _then);
+class _$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  _$InterfaceDeclarationStorageV3CopyWithImpl(this._self, this._then);
+
+  final InterfaceDeclarationStorageV3 _self;
+  final $Res Function(InterfaceDeclarationStorageV3) _then;
 
   /// Create a copy of InterfaceDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
@@ -194,49 +135,49 @@ class __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$InterfaceDeclarationStorageV3Impl(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       isSealed: null == isSealed
-          ? _value.isSealed
+          ? _self.isSealed
           : isSealed // ignore: cast_nullable_to_non_nullable
               as bool,
       isRequired: null == isRequired
-          ? _value.isRequired
+          ? _self.isRequired
           : isRequired // ignore: cast_nullable_to_non_nullable
               as bool,
       typeParameterNames: null == typeParameterNames
-          ? _value._typeParameterNames
+          ? _self.typeParameterNames
           : typeParameterNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       superTypeNames: null == superTypeNames
-          ? _value._superTypeNames
+          ? _self.superTypeNames
           : superTypeNames // ignore: cast_nullable_to_non_nullable
               as List<String>,
       executableDeclarations: null == executableDeclarations
-          ? _value._executableDeclarations
+          ? _self.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
       fieldDeclarations: null == fieldDeclarations
-          ? _value._fieldDeclarations
+          ? _self.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
       entryPoints: null == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -245,9 +186,8 @@ class __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$InterfaceDeclarationStorageV3Impl
-    extends _InterfaceDeclarationStorageV3 {
-  const _$InterfaceDeclarationStorageV3Impl(
+class _InterfaceDeclarationStorageV3 extends InterfaceDeclarationStorageV3 {
+  const _InterfaceDeclarationStorageV3(
       {required this.name,
       required this.isDeprecated,
       required this.isExperimental,
@@ -266,10 +206,8 @@ class _$InterfaceDeclarationStorageV3Impl
         _fieldDeclarations = fieldDeclarations,
         _entryPoints = entryPoints,
         super._();
-
-  factory _$InterfaceDeclarationStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$InterfaceDeclarationStorageV3ImplFromJson(json);
+  factory _InterfaceDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$InterfaceDeclarationStorageV3FromJson(json);
 
   @override
   final String name;
@@ -327,16 +265,27 @@ class _$InterfaceDeclarationStorageV3Impl
   @override
   final String relativePath;
 
+  /// Create a copy of InterfaceDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InterfaceDeclarationStorageV3CopyWith<_InterfaceDeclarationStorageV3>
+      get copyWith => __$InterfaceDeclarationStorageV3CopyWithImpl<
+          _InterfaceDeclarationStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$InterfaceDeclarationStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$InterfaceDeclarationStorageV3Impl &&
+            other is _InterfaceDeclarationStorageV3 &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.isDeprecated, isDeprecated) ||
                 other.isDeprecated == isDeprecated) &&
@@ -376,73 +325,107 @@ class _$InterfaceDeclarationStorageV3Impl
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
-  /// Create a copy of InterfaceDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$InterfaceDeclarationStorageV3ImplCopyWith<
-          _$InterfaceDeclarationStorageV3Impl>
-      get copyWith => __$$InterfaceDeclarationStorageV3ImplCopyWithImpl<
-          _$InterfaceDeclarationStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$InterfaceDeclarationStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'InterfaceDeclarationStorageV3(name: $name, isDeprecated: $isDeprecated, isExperimental: $isExperimental, isSealed: $isSealed, isRequired: $isRequired, typeParameterNames: $typeParameterNames, superTypeNames: $superTypeNames, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
-abstract class _InterfaceDeclarationStorageV3
-    extends InterfaceDeclarationStorageV3 {
-  const factory _InterfaceDeclarationStorageV3(
-          {required final String name,
-          required final bool isDeprecated,
-          required final bool isExperimental,
-          required final bool isSealed,
-          required final bool isRequired,
-          required final List<String> typeParameterNames,
-          required final List<String> superTypeNames,
-          required final List<ExecutableDeclarationStorageV3>
-              executableDeclarations,
-          required final List<FieldDeclarationStorageV3> fieldDeclarations,
-          required final Set<String> entryPoints,
-          required final String relativePath}) =
-      _$InterfaceDeclarationStorageV3Impl;
-  const _InterfaceDeclarationStorageV3._() : super._();
+/// @nodoc
+abstract mixin class _$InterfaceDeclarationStorageV3CopyWith<$Res>
+    implements $InterfaceDeclarationStorageV3CopyWith<$Res> {
+  factory _$InterfaceDeclarationStorageV3CopyWith(
+          _InterfaceDeclarationStorageV3 value,
+          $Res Function(_InterfaceDeclarationStorageV3) _then) =
+      __$InterfaceDeclarationStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      bool isDeprecated,
+      bool isExperimental,
+      bool isSealed,
+      bool isRequired,
+      List<String> typeParameterNames,
+      List<String> superTypeNames,
+      List<ExecutableDeclarationStorageV3> executableDeclarations,
+      List<FieldDeclarationStorageV3> fieldDeclarations,
+      Set<String> entryPoints,
+      String relativePath});
+}
 
-  factory _InterfaceDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$InterfaceDeclarationStorageV3Impl.fromJson;
+/// @nodoc
+class __$InterfaceDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$InterfaceDeclarationStorageV3CopyWith<$Res> {
+  __$InterfaceDeclarationStorageV3CopyWithImpl(this._self, this._then);
 
-  @override
-  String get name;
-  @override
-  bool get isDeprecated;
-  @override
-  bool get isExperimental;
-  @override
-  bool get isSealed;
-  @override
-  bool get isRequired;
-  @override
-  List<String> get typeParameterNames;
-  @override
-  List<String> get superTypeNames;
-  @override
-  List<ExecutableDeclarationStorageV3> get executableDeclarations;
-  @override
-  List<FieldDeclarationStorageV3> get fieldDeclarations;
-  @override
-  Set<String> get entryPoints;
-  @override
-  String get relativePath;
+  final _InterfaceDeclarationStorageV3 _self;
+  final $Res Function(_InterfaceDeclarationStorageV3) _then;
 
   /// Create a copy of InterfaceDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InterfaceDeclarationStorageV3ImplCopyWith<
-          _$InterfaceDeclarationStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? name = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? isSealed = null,
+    Object? isRequired = null,
+    Object? typeParameterNames = null,
+    Object? superTypeNames = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? entryPoints = null,
+    Object? relativePath = null,
+  }) {
+    return _then(_InterfaceDeclarationStorageV3(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSealed: null == isSealed
+          ? _self.isSealed
+          : isSealed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isRequired: null == isRequired
+          ? _self.isRequired
+          : isRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      typeParameterNames: null == typeParameterNames
+          ? _self._typeParameterNames
+          : typeParameterNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      superTypeNames: null == superTypeNames
+          ? _self._superTypeNames
+          : superTypeNames // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      executableDeclarations: null == executableDeclarations
+          ? _self._executableDeclarations
+          : executableDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableDeclarationStorageV3>,
+      fieldDeclarations: null == fieldDeclarations
+          ? _self._fieldDeclarations
+          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<FieldDeclarationStorageV3>,
+      entryPoints: null == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/interface_declaration_storage_v3.g.dart
@@ -8,37 +8,36 @@ part of 'interface_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$InterfaceDeclarationStorageV3Impl
-    _$$InterfaceDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
-        _$InterfaceDeclarationStorageV3Impl(
-          name: json['name'] as String,
-          isDeprecated: json['isDeprecated'] as bool,
-          isExperimental: json['isExperimental'] as bool,
-          isSealed: json['isSealed'] as bool,
-          isRequired: json['isRequired'] as bool,
-          typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
-              .map((e) => e as String)
-              .toList(),
-          superTypeNames: (json['superTypeNames'] as List<dynamic>)
-              .map((e) => e as String)
-              .toList(),
-          executableDeclarations:
-              (json['executableDeclarations'] as List<dynamic>)
-                  .map((e) => ExecutableDeclarationStorageV3.fromJson(
-                      e as Map<String, dynamic>))
-                  .toList(),
-          fieldDeclarations: (json['fieldDeclarations'] as List<dynamic>)
-              .map((e) =>
-                  FieldDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
-              .toList(),
-          entryPoints: (json['entryPoints'] as List<dynamic>)
-              .map((e) => e as String)
-              .toSet(),
-          relativePath: json['relativePath'] as String,
-        );
+_InterfaceDeclarationStorageV3 _$InterfaceDeclarationStorageV3FromJson(
+        Map<String, dynamic> json) =>
+    _InterfaceDeclarationStorageV3(
+      name: json['name'] as String,
+      isDeprecated: json['isDeprecated'] as bool,
+      isExperimental: json['isExperimental'] as bool,
+      isSealed: json['isSealed'] as bool,
+      isRequired: json['isRequired'] as bool,
+      typeParameterNames: (json['typeParameterNames'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      superTypeNames: (json['superTypeNames'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      executableDeclarations: (json['executableDeclarations'] as List<dynamic>)
+          .map((e) => ExecutableDeclarationStorageV3.fromJson(
+              e as Map<String, dynamic>))
+          .toList(),
+      fieldDeclarations: (json['fieldDeclarations'] as List<dynamic>)
+          .map((e) =>
+              FieldDeclarationStorageV3.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      entryPoints: (json['entryPoints'] as List<dynamic>)
+          .map((e) => e as String)
+          .toSet(),
+      relativePath: json['relativePath'] as String,
+    );
 
-Map<String, dynamic> _$$InterfaceDeclarationStorageV3ImplToJson(
-        _$InterfaceDeclarationStorageV3Impl instance) =>
+Map<String, dynamic> _$InterfaceDeclarationStorageV3ToJson(
+        _InterfaceDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'name': instance.name,
       'isDeprecated': instance.isDeprecated,

--- a/lib/src/storage/v3/package_api_storage_v3.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.dart
@@ -9,7 +9,7 @@ part 'package_api_storage_v3.freezed.dart';
 part 'package_api_storage_v3.g.dart';
 
 @freezed
-class PackageApiStorageV3 with _$PackageApiStorageV3 {
+sealed class PackageApiStorageV3 with _$PackageApiStorageV3 {
   const PackageApiStorageV3._();
 
   const factory PackageApiStorageV3({

--- a/lib/src/storage/v3/package_api_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,54 +10,99 @@ part of 'package_api_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-PackageApiStorageV3 _$PackageApiStorageV3FromJson(Map<String, dynamic> json) {
-  return _PackageApiStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$PackageApiStorageV3 {
-  String get packageName => throw _privateConstructorUsedError;
-  String? get packageVersion => throw _privateConstructorUsedError;
-  String get packagePath => throw _privateConstructorUsedError;
-  List<InterfaceDeclarationStorageV3> get interfaceDeclarations =>
-      throw _privateConstructorUsedError;
-  List<ExecutableDeclarationStorageV3> get executableDeclarations =>
-      throw _privateConstructorUsedError;
-  List<FieldDeclarationStorageV3> get fieldDeclarations =>
-      throw _privateConstructorUsedError;
-  List<TypeAliasDeclarationStorageV3> get typeAliasDeclarations =>
-      throw _privateConstructorUsedError;
-  Set<PackageApiSemantics> get semantics => throw _privateConstructorUsedError;
-  IOSPlatformConstraintsStorageV3? get iosPlatformConstraints =>
-      throw _privateConstructorUsedError;
-  AndroidPlatformConstraintsStorageV3? get androidPlatformConstraints =>
-      throw _privateConstructorUsedError;
-  SdkTypeStorageV3 get sdkType => throw _privateConstructorUsedError;
+  String get packageName;
+  String? get packageVersion;
+  String get packagePath;
+  List<InterfaceDeclarationStorageV3> get interfaceDeclarations;
+  List<ExecutableDeclarationStorageV3> get executableDeclarations;
+  List<FieldDeclarationStorageV3> get fieldDeclarations;
+  List<TypeAliasDeclarationStorageV3> get typeAliasDeclarations;
+  Set<PackageApiSemantics> get semantics;
+  IOSPlatformConstraintsStorageV3? get iosPlatformConstraints;
+  AndroidPlatformConstraintsStorageV3? get androidPlatformConstraints;
+  SdkTypeStorageV3 get sdkType;
   @VersionJsonConverter()
-  Version get minSdkVersion => throw _privateConstructorUsedError;
-  List<PackageDependencyStorageV3> get packageDependencies =>
-      throw _privateConstructorUsedError;
-
-  /// Serializes this PackageApiStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  Version get minSdkVersion;
+  List<PackageDependencyStorageV3> get packageDependencies;
 
   /// Create a copy of PackageApiStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $PackageApiStorageV3CopyWith<PackageApiStorageV3> get copyWith =>
-      throw _privateConstructorUsedError;
+      _$PackageApiStorageV3CopyWithImpl<PackageApiStorageV3>(
+          this as PackageApiStorageV3, _$identity);
+
+  /// Serializes this PackageApiStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PackageApiStorageV3 &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion) &&
+            (identical(other.packagePath, packagePath) ||
+                other.packagePath == packagePath) &&
+            const DeepCollectionEquality()
+                .equals(other.interfaceDeclarations, interfaceDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.executableDeclarations, executableDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.fieldDeclarations, fieldDeclarations) &&
+            const DeepCollectionEquality()
+                .equals(other.typeAliasDeclarations, typeAliasDeclarations) &&
+            const DeepCollectionEquality().equals(other.semantics, semantics) &&
+            (identical(other.iosPlatformConstraints, iosPlatformConstraints) ||
+                other.iosPlatformConstraints == iosPlatformConstraints) &&
+            (identical(other.androidPlatformConstraints,
+                    androidPlatformConstraints) ||
+                other.androidPlatformConstraints ==
+                    androidPlatformConstraints) &&
+            (identical(other.sdkType, sdkType) || other.sdkType == sdkType) &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            const DeepCollectionEquality()
+                .equals(other.packageDependencies, packageDependencies));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      packageName,
+      packageVersion,
+      packagePath,
+      const DeepCollectionEquality().hash(interfaceDeclarations),
+      const DeepCollectionEquality().hash(executableDeclarations),
+      const DeepCollectionEquality().hash(fieldDeclarations),
+      const DeepCollectionEquality().hash(typeAliasDeclarations),
+      const DeepCollectionEquality().hash(semantics),
+      iosPlatformConstraints,
+      androidPlatformConstraints,
+      sdkType,
+      minSdkVersion,
+      const DeepCollectionEquality().hash(packageDependencies));
+
+  @override
+  String toString() {
+    return 'PackageApiStorageV3(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, iosPlatformConstraints: $iosPlatformConstraints, androidPlatformConstraints: $androidPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion, packageDependencies: $packageDependencies)';
+  }
 }
 
 /// @nodoc
-abstract class $PackageApiStorageV3CopyWith<$Res> {
+abstract mixin class $PackageApiStorageV3CopyWith<$Res> {
   factory $PackageApiStorageV3CopyWith(
-          PackageApiStorageV3 value, $Res Function(PackageApiStorageV3) then) =
-      _$PackageApiStorageV3CopyWithImpl<$Res, PackageApiStorageV3>;
+          PackageApiStorageV3 value, $Res Function(PackageApiStorageV3) _then) =
+      _$PackageApiStorageV3CopyWithImpl;
   @useResult
   $Res call(
       {String packageName,
@@ -79,14 +125,12 @@ abstract class $PackageApiStorageV3CopyWith<$Res> {
 }
 
 /// @nodoc
-class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
+class _$PackageApiStorageV3CopyWithImpl<$Res>
     implements $PackageApiStorageV3CopyWith<$Res> {
-  _$PackageApiStorageV3CopyWithImpl(this._value, this._then);
+  _$PackageApiStorageV3CopyWithImpl(this._self, this._then);
 
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
+  final PackageApiStorageV3 _self;
+  final $Res Function(PackageApiStorageV3) _then;
 
   /// Create a copy of PackageApiStorageV3
   /// with the given fields replaced by the non-null parameter values.
@@ -107,60 +151,60 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
     Object? minSdkVersion = null,
     Object? packageDependencies = null,
   }) {
-    return _then(_value.copyWith(
+    return _then(_self.copyWith(
       packageName: null == packageName
-          ? _value.packageName
+          ? _self.packageName
           : packageName // ignore: cast_nullable_to_non_nullable
               as String,
       packageVersion: freezed == packageVersion
-          ? _value.packageVersion
+          ? _self.packageVersion
           : packageVersion // ignore: cast_nullable_to_non_nullable
               as String?,
       packagePath: null == packagePath
-          ? _value.packagePath
+          ? _self.packagePath
           : packagePath // ignore: cast_nullable_to_non_nullable
               as String,
       interfaceDeclarations: null == interfaceDeclarations
-          ? _value.interfaceDeclarations
+          ? _self.interfaceDeclarations
           : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
               as List<InterfaceDeclarationStorageV3>,
       executableDeclarations: null == executableDeclarations
-          ? _value.executableDeclarations
+          ? _self.executableDeclarations
           : executableDeclarations // ignore: cast_nullable_to_non_nullable
               as List<ExecutableDeclarationStorageV3>,
       fieldDeclarations: null == fieldDeclarations
-          ? _value.fieldDeclarations
+          ? _self.fieldDeclarations
           : fieldDeclarations // ignore: cast_nullable_to_non_nullable
               as List<FieldDeclarationStorageV3>,
       typeAliasDeclarations: null == typeAliasDeclarations
-          ? _value.typeAliasDeclarations
+          ? _self.typeAliasDeclarations
           : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
               as List<TypeAliasDeclarationStorageV3>,
       semantics: null == semantics
-          ? _value.semantics
+          ? _self.semantics
           : semantics // ignore: cast_nullable_to_non_nullable
               as Set<PackageApiSemantics>,
       iosPlatformConstraints: freezed == iosPlatformConstraints
-          ? _value.iosPlatformConstraints
+          ? _self.iosPlatformConstraints
           : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as IOSPlatformConstraintsStorageV3?,
       androidPlatformConstraints: freezed == androidPlatformConstraints
-          ? _value.androidPlatformConstraints
+          ? _self.androidPlatformConstraints
           : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
               as AndroidPlatformConstraintsStorageV3?,
       sdkType: null == sdkType
-          ? _value.sdkType
+          ? _self.sdkType
           : sdkType // ignore: cast_nullable_to_non_nullable
               as SdkTypeStorageV3,
       minSdkVersion: null == minSdkVersion
-          ? _value.minSdkVersion
+          ? _self.minSdkVersion
           : minSdkVersion // ignore: cast_nullable_to_non_nullable
               as Version,
       packageDependencies: null == packageDependencies
-          ? _value.packageDependencies
+          ? _self.packageDependencies
           : packageDependencies // ignore: cast_nullable_to_non_nullable
               as List<PackageDependencyStorageV3>,
-    ) as $Val);
+    ));
   }
 
   /// Create a copy of PackageApiStorageV3
@@ -168,13 +212,13 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
   @override
   @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints {
-    if (_value.iosPlatformConstraints == null) {
+    if (_self.iosPlatformConstraints == null) {
       return null;
     }
 
     return $IOSPlatformConstraintsStorageV3CopyWith<$Res>(
-        _value.iosPlatformConstraints!, (value) {
-      return _then(_value.copyWith(iosPlatformConstraints: value) as $Val);
+        _self.iosPlatformConstraints!, (value) {
+      return _then(_self.copyWith(iosPlatformConstraints: value));
     });
   }
 
@@ -184,135 +228,21 @@ class _$PackageApiStorageV3CopyWithImpl<$Res, $Val extends PackageApiStorageV3>
   @pragma('vm:prefer-inline')
   $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
       get androidPlatformConstraints {
-    if (_value.androidPlatformConstraints == null) {
+    if (_self.androidPlatformConstraints == null) {
       return null;
     }
 
     return $AndroidPlatformConstraintsStorageV3CopyWith<$Res>(
-        _value.androidPlatformConstraints!, (value) {
-      return _then(_value.copyWith(androidPlatformConstraints: value) as $Val);
+        _self.androidPlatformConstraints!, (value) {
+      return _then(_self.copyWith(androidPlatformConstraints: value));
     });
   }
 }
 
 /// @nodoc
-abstract class _$$PackageApiStorageV3ImplCopyWith<$Res>
-    implements $PackageApiStorageV3CopyWith<$Res> {
-  factory _$$PackageApiStorageV3ImplCopyWith(_$PackageApiStorageV3Impl value,
-          $Res Function(_$PackageApiStorageV3Impl) then) =
-      __$$PackageApiStorageV3ImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String packageName,
-      String? packageVersion,
-      String packagePath,
-      List<InterfaceDeclarationStorageV3> interfaceDeclarations,
-      List<ExecutableDeclarationStorageV3> executableDeclarations,
-      List<FieldDeclarationStorageV3> fieldDeclarations,
-      List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
-      Set<PackageApiSemantics> semantics,
-      IOSPlatformConstraintsStorageV3? iosPlatformConstraints,
-      AndroidPlatformConstraintsStorageV3? androidPlatformConstraints,
-      SdkTypeStorageV3 sdkType,
-      @VersionJsonConverter() Version minSdkVersion,
-      List<PackageDependencyStorageV3> packageDependencies});
-
-  @override
-  $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints;
-  @override
-  $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
-      get androidPlatformConstraints;
-}
-
-/// @nodoc
-class __$$PackageApiStorageV3ImplCopyWithImpl<$Res>
-    extends _$PackageApiStorageV3CopyWithImpl<$Res, _$PackageApiStorageV3Impl>
-    implements _$$PackageApiStorageV3ImplCopyWith<$Res> {
-  __$$PackageApiStorageV3ImplCopyWithImpl(_$PackageApiStorageV3Impl _value,
-      $Res Function(_$PackageApiStorageV3Impl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PackageApiStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-    Object? packagePath = null,
-    Object? interfaceDeclarations = null,
-    Object? executableDeclarations = null,
-    Object? fieldDeclarations = null,
-    Object? typeAliasDeclarations = null,
-    Object? semantics = null,
-    Object? iosPlatformConstraints = freezed,
-    Object? androidPlatformConstraints = freezed,
-    Object? sdkType = null,
-    Object? minSdkVersion = null,
-    Object? packageDependencies = null,
-  }) {
-    return _then(_$PackageApiStorageV3Impl(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-      packagePath: null == packagePath
-          ? _value.packagePath
-          : packagePath // ignore: cast_nullable_to_non_nullable
-              as String,
-      interfaceDeclarations: null == interfaceDeclarations
-          ? _value._interfaceDeclarations
-          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<InterfaceDeclarationStorageV3>,
-      executableDeclarations: null == executableDeclarations
-          ? _value._executableDeclarations
-          : executableDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<ExecutableDeclarationStorageV3>,
-      fieldDeclarations: null == fieldDeclarations
-          ? _value._fieldDeclarations
-          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<FieldDeclarationStorageV3>,
-      typeAliasDeclarations: null == typeAliasDeclarations
-          ? _value._typeAliasDeclarations
-          : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
-              as List<TypeAliasDeclarationStorageV3>,
-      semantics: null == semantics
-          ? _value._semantics
-          : semantics // ignore: cast_nullable_to_non_nullable
-              as Set<PackageApiSemantics>,
-      iosPlatformConstraints: freezed == iosPlatformConstraints
-          ? _value.iosPlatformConstraints
-          : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
-              as IOSPlatformConstraintsStorageV3?,
-      androidPlatformConstraints: freezed == androidPlatformConstraints
-          ? _value.androidPlatformConstraints
-          : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
-              as AndroidPlatformConstraintsStorageV3?,
-      sdkType: null == sdkType
-          ? _value.sdkType
-          : sdkType // ignore: cast_nullable_to_non_nullable
-              as SdkTypeStorageV3,
-      minSdkVersion: null == minSdkVersion
-          ? _value.minSdkVersion
-          : minSdkVersion // ignore: cast_nullable_to_non_nullable
-              as Version,
-      packageDependencies: null == packageDependencies
-          ? _value._packageDependencies
-          : packageDependencies // ignore: cast_nullable_to_non_nullable
-              as List<PackageDependencyStorageV3>,
-    ));
-  }
-}
-
-/// @nodoc
 @JsonSerializable()
-class _$PackageApiStorageV3Impl extends _PackageApiStorageV3 {
-  const _$PackageApiStorageV3Impl(
+class _PackageApiStorageV3 extends PackageApiStorageV3 {
+  const _PackageApiStorageV3(
       {required this.packageName,
       required this.packageVersion,
       required this.packagePath,
@@ -334,9 +264,8 @@ class _$PackageApiStorageV3Impl extends _PackageApiStorageV3 {
         _semantics = semantics,
         _packageDependencies = packageDependencies,
         super._();
-
-  factory _$PackageApiStorageV3Impl.fromJson(Map<String, dynamic> json) =>
-      _$$PackageApiStorageV3ImplFromJson(json);
+  factory _PackageApiStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$PackageApiStorageV3FromJson(json);
 
   @override
   final String packageName;
@@ -406,16 +335,27 @@ class _$PackageApiStorageV3Impl extends _PackageApiStorageV3 {
     return EqualUnmodifiableListView(_packageDependencies);
   }
 
+  /// Create a copy of PackageApiStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'PackageApiStorageV3(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, iosPlatformConstraints: $iosPlatformConstraints, androidPlatformConstraints: $androidPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion, packageDependencies: $packageDependencies)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PackageApiStorageV3CopyWith<_PackageApiStorageV3> get copyWith =>
+      __$PackageApiStorageV3CopyWithImpl<_PackageApiStorageV3>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PackageApiStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PackageApiStorageV3Impl &&
+            other is _PackageApiStorageV3 &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -463,77 +403,155 @@ class _$PackageApiStorageV3Impl extends _PackageApiStorageV3 {
       minSdkVersion,
       const DeepCollectionEquality().hash(_packageDependencies));
 
-  /// Create a copy of PackageApiStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$PackageApiStorageV3ImplCopyWith<_$PackageApiStorageV3Impl> get copyWith =>
-      __$$PackageApiStorageV3ImplCopyWithImpl<_$PackageApiStorageV3Impl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$PackageApiStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'PackageApiStorageV3(packageName: $packageName, packageVersion: $packageVersion, packagePath: $packagePath, interfaceDeclarations: $interfaceDeclarations, executableDeclarations: $executableDeclarations, fieldDeclarations: $fieldDeclarations, typeAliasDeclarations: $typeAliasDeclarations, semantics: $semantics, iosPlatformConstraints: $iosPlatformConstraints, androidPlatformConstraints: $androidPlatformConstraints, sdkType: $sdkType, minSdkVersion: $minSdkVersion, packageDependencies: $packageDependencies)';
   }
 }
 
-abstract class _PackageApiStorageV3 extends PackageApiStorageV3 {
-  const factory _PackageApiStorageV3(
-      {required final String packageName,
-      required final String? packageVersion,
-      required final String packagePath,
-      required final List<InterfaceDeclarationStorageV3> interfaceDeclarations,
-      required final List<ExecutableDeclarationStorageV3>
-          executableDeclarations,
-      required final List<FieldDeclarationStorageV3> fieldDeclarations,
-      required final List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
-      required final Set<PackageApiSemantics> semantics,
-      final IOSPlatformConstraintsStorageV3? iosPlatformConstraints,
-      final AndroidPlatformConstraintsStorageV3? androidPlatformConstraints,
-      required final SdkTypeStorageV3 sdkType,
-      @VersionJsonConverter() required final Version minSdkVersion,
-      required final List<PackageDependencyStorageV3>
-          packageDependencies}) = _$PackageApiStorageV3Impl;
-  const _PackageApiStorageV3._() : super._();
+/// @nodoc
+abstract mixin class _$PackageApiStorageV3CopyWith<$Res>
+    implements $PackageApiStorageV3CopyWith<$Res> {
+  factory _$PackageApiStorageV3CopyWith(_PackageApiStorageV3 value,
+          $Res Function(_PackageApiStorageV3) _then) =
+      __$PackageApiStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String packageName,
+      String? packageVersion,
+      String packagePath,
+      List<InterfaceDeclarationStorageV3> interfaceDeclarations,
+      List<ExecutableDeclarationStorageV3> executableDeclarations,
+      List<FieldDeclarationStorageV3> fieldDeclarations,
+      List<TypeAliasDeclarationStorageV3> typeAliasDeclarations,
+      Set<PackageApiSemantics> semantics,
+      IOSPlatformConstraintsStorageV3? iosPlatformConstraints,
+      AndroidPlatformConstraintsStorageV3? androidPlatformConstraints,
+      SdkTypeStorageV3 sdkType,
+      @VersionJsonConverter() Version minSdkVersion,
+      List<PackageDependencyStorageV3> packageDependencies});
 
-  factory _PackageApiStorageV3.fromJson(Map<String, dynamic> json) =
-      _$PackageApiStorageV3Impl.fromJson;
+  @override
+  $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints;
+  @override
+  $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
+      get androidPlatformConstraints;
+}
 
-  @override
-  String get packageName;
-  @override
-  String? get packageVersion;
-  @override
-  String get packagePath;
-  @override
-  List<InterfaceDeclarationStorageV3> get interfaceDeclarations;
-  @override
-  List<ExecutableDeclarationStorageV3> get executableDeclarations;
-  @override
-  List<FieldDeclarationStorageV3> get fieldDeclarations;
-  @override
-  List<TypeAliasDeclarationStorageV3> get typeAliasDeclarations;
-  @override
-  Set<PackageApiSemantics> get semantics;
-  @override
-  IOSPlatformConstraintsStorageV3? get iosPlatformConstraints;
-  @override
-  AndroidPlatformConstraintsStorageV3? get androidPlatformConstraints;
-  @override
-  SdkTypeStorageV3 get sdkType;
-  @override
-  @VersionJsonConverter()
-  Version get minSdkVersion;
-  @override
-  List<PackageDependencyStorageV3> get packageDependencies;
+/// @nodoc
+class __$PackageApiStorageV3CopyWithImpl<$Res>
+    implements _$PackageApiStorageV3CopyWith<$Res> {
+  __$PackageApiStorageV3CopyWithImpl(this._self, this._then);
+
+  final _PackageApiStorageV3 _self;
+  final $Res Function(_PackageApiStorageV3) _then;
 
   /// Create a copy of PackageApiStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PackageApiStorageV3ImplCopyWith<_$PackageApiStorageV3Impl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+    Object? packagePath = null,
+    Object? interfaceDeclarations = null,
+    Object? executableDeclarations = null,
+    Object? fieldDeclarations = null,
+    Object? typeAliasDeclarations = null,
+    Object? semantics = null,
+    Object? iosPlatformConstraints = freezed,
+    Object? androidPlatformConstraints = freezed,
+    Object? sdkType = null,
+    Object? minSdkVersion = null,
+    Object? packageDependencies = null,
+  }) {
+    return _then(_PackageApiStorageV3(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+      packagePath: null == packagePath
+          ? _self.packagePath
+          : packagePath // ignore: cast_nullable_to_non_nullable
+              as String,
+      interfaceDeclarations: null == interfaceDeclarations
+          ? _self._interfaceDeclarations
+          : interfaceDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<InterfaceDeclarationStorageV3>,
+      executableDeclarations: null == executableDeclarations
+          ? _self._executableDeclarations
+          : executableDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<ExecutableDeclarationStorageV3>,
+      fieldDeclarations: null == fieldDeclarations
+          ? _self._fieldDeclarations
+          : fieldDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<FieldDeclarationStorageV3>,
+      typeAliasDeclarations: null == typeAliasDeclarations
+          ? _self._typeAliasDeclarations
+          : typeAliasDeclarations // ignore: cast_nullable_to_non_nullable
+              as List<TypeAliasDeclarationStorageV3>,
+      semantics: null == semantics
+          ? _self._semantics
+          : semantics // ignore: cast_nullable_to_non_nullable
+              as Set<PackageApiSemantics>,
+      iosPlatformConstraints: freezed == iosPlatformConstraints
+          ? _self.iosPlatformConstraints
+          : iosPlatformConstraints // ignore: cast_nullable_to_non_nullable
+              as IOSPlatformConstraintsStorageV3?,
+      androidPlatformConstraints: freezed == androidPlatformConstraints
+          ? _self.androidPlatformConstraints
+          : androidPlatformConstraints // ignore: cast_nullable_to_non_nullable
+              as AndroidPlatformConstraintsStorageV3?,
+      sdkType: null == sdkType
+          ? _self.sdkType
+          : sdkType // ignore: cast_nullable_to_non_nullable
+              as SdkTypeStorageV3,
+      minSdkVersion: null == minSdkVersion
+          ? _self.minSdkVersion
+          : minSdkVersion // ignore: cast_nullable_to_non_nullable
+              as Version,
+      packageDependencies: null == packageDependencies
+          ? _self._packageDependencies
+          : packageDependencies // ignore: cast_nullable_to_non_nullable
+              as List<PackageDependencyStorageV3>,
+    ));
+  }
+
+  /// Create a copy of PackageApiStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $IOSPlatformConstraintsStorageV3CopyWith<$Res>? get iosPlatformConstraints {
+    if (_self.iosPlatformConstraints == null) {
+      return null;
+    }
+
+    return $IOSPlatformConstraintsStorageV3CopyWith<$Res>(
+        _self.iosPlatformConstraints!, (value) {
+      return _then(_self.copyWith(iosPlatformConstraints: value));
+    });
+  }
+
+  /// Create a copy of PackageApiStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AndroidPlatformConstraintsStorageV3CopyWith<$Res>?
+      get androidPlatformConstraints {
+    if (_self.androidPlatformConstraints == null) {
+      return null;
+    }
+
+    return $AndroidPlatformConstraintsStorageV3CopyWith<$Res>(
+        _self.androidPlatformConstraints!, (value) {
+      return _then(_self.copyWith(androidPlatformConstraints: value));
+    });
+  }
 }
+
+// dart format on

--- a/lib/src/storage/v3/package_api_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_api_storage_v3.g.dart
@@ -8,9 +8,8 @@ part of 'package_api_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PackageApiStorageV3Impl _$$PackageApiStorageV3ImplFromJson(
-        Map<String, dynamic> json) =>
-    _$PackageApiStorageV3Impl(
+_PackageApiStorageV3 _$PackageApiStorageV3FromJson(Map<String, dynamic> json) =>
+    _PackageApiStorageV3(
       packageName: json['packageName'] as String,
       packageVersion: json['packageVersion'] as String?,
       packagePath: json['packagePath'] as String,
@@ -50,8 +49,8 @@ _$PackageApiStorageV3Impl _$$PackageApiStorageV3ImplFromJson(
           .toList(),
     );
 
-Map<String, dynamic> _$$PackageApiStorageV3ImplToJson(
-        _$PackageApiStorageV3Impl instance) =>
+Map<String, dynamic> _$PackageApiStorageV3ToJson(
+        _PackageApiStorageV3 instance) =>
     <String, dynamic>{
       'packageName': instance.packageName,
       'packageVersion': instance.packageVersion,

--- a/lib/src/storage/v3/package_dependency_storage_v3.dart
+++ b/lib/src/storage/v3/package_dependency_storage_v3.dart
@@ -7,7 +7,7 @@ part 'package_dependency_storage_v3.g.dart';
 
 /// represents a package dependency
 @freezed
-class PackageDependencyStorageV3 with _$PackageDependencyStorageV3 {
+sealed class PackageDependencyStorageV3 with _$PackageDependencyStorageV3 {
   const PackageDependencyStorageV3._();
 
   const factory PackageDependencyStorageV3({

--- a/lib/src/storage/v3/package_dependency_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/package_dependency_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,142 +10,31 @@ part of 'package_dependency_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-PackageDependencyStorageV3 _$PackageDependencyStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _PackageDependencyStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$PackageDependencyStorageV3 {
-  String get packageName => throw _privateConstructorUsedError;
-  String? get packageVersion => throw _privateConstructorUsedError;
-
-  /// Serializes this PackageDependencyStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get packageName;
+  String? get packageVersion;
 
   /// Create a copy of PackageDependencyStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $PackageDependencyStorageV3CopyWith<PackageDependencyStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
+      get copyWith =>
+          _$PackageDependencyStorageV3CopyWithImpl<PackageDependencyStorageV3>(
+              this as PackageDependencyStorageV3, _$identity);
 
-/// @nodoc
-abstract class $PackageDependencyStorageV3CopyWith<$Res> {
-  factory $PackageDependencyStorageV3CopyWith(PackageDependencyStorageV3 value,
-          $Res Function(PackageDependencyStorageV3) then) =
-      _$PackageDependencyStorageV3CopyWithImpl<$Res,
-          PackageDependencyStorageV3>;
-  @useResult
-  $Res call({String packageName, String? packageVersion});
-}
-
-/// @nodoc
-class _$PackageDependencyStorageV3CopyWithImpl<$Res,
-        $Val extends PackageDependencyStorageV3>
-    implements $PackageDependencyStorageV3CopyWith<$Res> {
-  _$PackageDependencyStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of PackageDependencyStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$PackageDependencyStorageV3ImplCopyWith<$Res>
-    implements $PackageDependencyStorageV3CopyWith<$Res> {
-  factory _$$PackageDependencyStorageV3ImplCopyWith(
-          _$PackageDependencyStorageV3Impl value,
-          $Res Function(_$PackageDependencyStorageV3Impl) then) =
-      __$$PackageDependencyStorageV3ImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String packageName, String? packageVersion});
-}
-
-/// @nodoc
-class __$$PackageDependencyStorageV3ImplCopyWithImpl<$Res>
-    extends _$PackageDependencyStorageV3CopyWithImpl<$Res,
-        _$PackageDependencyStorageV3Impl>
-    implements _$$PackageDependencyStorageV3ImplCopyWith<$Res> {
-  __$$PackageDependencyStorageV3ImplCopyWithImpl(
-      _$PackageDependencyStorageV3Impl _value,
-      $Res Function(_$PackageDependencyStorageV3Impl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of PackageDependencyStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? packageName = null,
-    Object? packageVersion = freezed,
-  }) {
-    return _then(_$PackageDependencyStorageV3Impl(
-      packageName: null == packageName
-          ? _value.packageName
-          : packageName // ignore: cast_nullable_to_non_nullable
-              as String,
-      packageVersion: freezed == packageVersion
-          ? _value.packageVersion
-          : packageVersion // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$PackageDependencyStorageV3Impl extends _PackageDependencyStorageV3 {
-  const _$PackageDependencyStorageV3Impl(
-      {required this.packageName, required this.packageVersion})
-      : super._();
-
-  factory _$PackageDependencyStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$PackageDependencyStorageV3ImplFromJson(json);
-
-  @override
-  final String packageName;
-  @override
-  final String? packageVersion;
-
-  @override
-  String toString() {
-    return 'PackageDependencyStorageV3(packageName: $packageName, packageVersion: $packageVersion)';
-  }
+  /// Serializes this PackageDependencyStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$PackageDependencyStorageV3Impl &&
+            other is PackageDependencyStorageV3 &&
             (identical(other.packageName, packageName) ||
                 other.packageName == packageName) &&
             (identical(other.packageVersion, packageVersion) ||
@@ -155,42 +45,140 @@ class _$PackageDependencyStorageV3Impl extends _PackageDependencyStorageV3 {
   @override
   int get hashCode => Object.hash(runtimeType, packageName, packageVersion);
 
-  /// Create a copy of PackageDependencyStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$PackageDependencyStorageV3ImplCopyWith<_$PackageDependencyStorageV3Impl>
-      get copyWith => __$$PackageDependencyStorageV3ImplCopyWithImpl<
-          _$PackageDependencyStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$PackageDependencyStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'PackageDependencyStorageV3(packageName: $packageName, packageVersion: $packageVersion)';
   }
 }
 
-abstract class _PackageDependencyStorageV3 extends PackageDependencyStorageV3 {
-  const factory _PackageDependencyStorageV3(
-          {required final String packageName,
-          required final String? packageVersion}) =
-      _$PackageDependencyStorageV3Impl;
-  const _PackageDependencyStorageV3._() : super._();
+/// @nodoc
+abstract mixin class $PackageDependencyStorageV3CopyWith<$Res> {
+  factory $PackageDependencyStorageV3CopyWith(PackageDependencyStorageV3 value,
+          $Res Function(PackageDependencyStorageV3) _then) =
+      _$PackageDependencyStorageV3CopyWithImpl;
+  @useResult
+  $Res call({String packageName, String? packageVersion});
+}
 
-  factory _PackageDependencyStorageV3.fromJson(Map<String, dynamic> json) =
-      _$PackageDependencyStorageV3Impl.fromJson;
+/// @nodoc
+class _$PackageDependencyStorageV3CopyWithImpl<$Res>
+    implements $PackageDependencyStorageV3CopyWith<$Res> {
+  _$PackageDependencyStorageV3CopyWithImpl(this._self, this._then);
+
+  final PackageDependencyStorageV3 _self;
+  final $Res Function(PackageDependencyStorageV3) _then;
+
+  /// Create a copy of PackageDependencyStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+  }) {
+    return _then(_self.copyWith(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _PackageDependencyStorageV3 extends PackageDependencyStorageV3 {
+  const _PackageDependencyStorageV3(
+      {required this.packageName, required this.packageVersion})
+      : super._();
+  factory _PackageDependencyStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$PackageDependencyStorageV3FromJson(json);
 
   @override
-  String get packageName;
+  final String packageName;
   @override
-  String? get packageVersion;
+  final String? packageVersion;
 
   /// Create a copy of PackageDependencyStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$PackageDependencyStorageV3ImplCopyWith<_$PackageDependencyStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$PackageDependencyStorageV3CopyWith<_PackageDependencyStorageV3>
+      get copyWith => __$PackageDependencyStorageV3CopyWithImpl<
+          _PackageDependencyStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PackageDependencyStorageV3ToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PackageDependencyStorageV3 &&
+            (identical(other.packageName, packageName) ||
+                other.packageName == packageName) &&
+            (identical(other.packageVersion, packageVersion) ||
+                other.packageVersion == packageVersion));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, packageName, packageVersion);
+
+  @override
+  String toString() {
+    return 'PackageDependencyStorageV3(packageName: $packageName, packageVersion: $packageVersion)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$PackageDependencyStorageV3CopyWith<$Res>
+    implements $PackageDependencyStorageV3CopyWith<$Res> {
+  factory _$PackageDependencyStorageV3CopyWith(
+          _PackageDependencyStorageV3 value,
+          $Res Function(_PackageDependencyStorageV3) _then) =
+      __$PackageDependencyStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call({String packageName, String? packageVersion});
+}
+
+/// @nodoc
+class __$PackageDependencyStorageV3CopyWithImpl<$Res>
+    implements _$PackageDependencyStorageV3CopyWith<$Res> {
+  __$PackageDependencyStorageV3CopyWithImpl(this._self, this._then);
+
+  final _PackageDependencyStorageV3 _self;
+  final $Res Function(_PackageDependencyStorageV3) _then;
+
+  /// Create a copy of PackageDependencyStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? packageName = null,
+    Object? packageVersion = freezed,
+  }) {
+    return _then(_PackageDependencyStorageV3(
+      packageName: null == packageName
+          ? _self.packageName
+          : packageName // ignore: cast_nullable_to_non_nullable
+              as String,
+      packageVersion: freezed == packageVersion
+          ? _self.packageVersion
+          : packageVersion // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/storage/v3/package_dependency_storage_v3.g.dart
+++ b/lib/src/storage/v3/package_dependency_storage_v3.g.dart
@@ -8,15 +8,15 @@ part of 'package_dependency_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$PackageDependencyStorageV3Impl _$$PackageDependencyStorageV3ImplFromJson(
+_PackageDependencyStorageV3 _$PackageDependencyStorageV3FromJson(
         Map<String, dynamic> json) =>
-    _$PackageDependencyStorageV3Impl(
+    _PackageDependencyStorageV3(
       packageName: json['packageName'] as String,
       packageVersion: json['packageVersion'] as String?,
     );
 
-Map<String, dynamic> _$$PackageDependencyStorageV3ImplToJson(
-        _$PackageDependencyStorageV3Impl instance) =>
+Map<String, dynamic> _$PackageDependencyStorageV3ToJson(
+        _PackageDependencyStorageV3 instance) =>
     <String, dynamic>{
       'packageName': instance.packageName,
       'packageVersion': instance.packageVersion,

--- a/lib/src/storage/v3/platform_constraints_storage_v3.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.dart
@@ -6,7 +6,8 @@ part 'platform_constraints_storage_v3.freezed.dart';
 part 'platform_constraints_storage_v3.g.dart';
 
 @freezed
-class IOSPlatformConstraintsStorageV3 with _$IOSPlatformConstraintsStorageV3 {
+sealed class IOSPlatformConstraintsStorageV3
+    with _$IOSPlatformConstraintsStorageV3 {
   const IOSPlatformConstraintsStorageV3._();
 
   const factory IOSPlatformConstraintsStorageV3({
@@ -28,7 +29,7 @@ class IOSPlatformConstraintsStorageV3 with _$IOSPlatformConstraintsStorageV3 {
 }
 
 @freezed
-class AndroidPlatformConstraintsStorageV3
+sealed class AndroidPlatformConstraintsStorageV3
     with _$AndroidPlatformConstraintsStorageV3 {
   const AndroidPlatformConstraintsStorageV3._();
 

--- a/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,130 +10,30 @@ part of 'platform_constraints_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-IOSPlatformConstraintsStorageV3 _$IOSPlatformConstraintsStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _IOSPlatformConstraintsStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$IOSPlatformConstraintsStorageV3 {
-  num? get minimumOsVersion => throw _privateConstructorUsedError;
-
-  /// Serializes this IOSPlatformConstraintsStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  num? get minimumOsVersion;
 
   /// Create a copy of IOSPlatformConstraintsStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $IOSPlatformConstraintsStorageV3CopyWith<IOSPlatformConstraintsStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
+      get copyWith => _$IOSPlatformConstraintsStorageV3CopyWithImpl<
+              IOSPlatformConstraintsStorageV3>(
+          this as IOSPlatformConstraintsStorageV3, _$identity);
 
-/// @nodoc
-abstract class $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory $IOSPlatformConstraintsStorageV3CopyWith(
-          IOSPlatformConstraintsStorageV3 value,
-          $Res Function(IOSPlatformConstraintsStorageV3) then) =
-      _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-          IOSPlatformConstraintsStorageV3>;
-  @useResult
-  $Res call({num? minimumOsVersion});
-}
-
-/// @nodoc
-class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        $Val extends IOSPlatformConstraintsStorageV3>
-    implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
-  _$IOSPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of IOSPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? minimumOsVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      minimumOsVersion: freezed == minimumOsVersion
-          ? _value.minimumOsVersion
-          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
-              as num?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$IOSPlatformConstraintsStorageV3ImplCopyWith<$Res>
-    implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory _$$IOSPlatformConstraintsStorageV3ImplCopyWith(
-          _$IOSPlatformConstraintsStorageV3Impl value,
-          $Res Function(_$IOSPlatformConstraintsStorageV3Impl) then) =
-      __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({num? minimumOsVersion});
-}
-
-/// @nodoc
-class __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>
-    extends _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$IOSPlatformConstraintsStorageV3Impl>
-    implements _$$IOSPlatformConstraintsStorageV3ImplCopyWith<$Res> {
-  __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl(
-      _$IOSPlatformConstraintsStorageV3Impl _value,
-      $Res Function(_$IOSPlatformConstraintsStorageV3Impl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of IOSPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? minimumOsVersion = freezed,
-  }) {
-    return _then(_$IOSPlatformConstraintsStorageV3Impl(
-      minimumOsVersion: freezed == minimumOsVersion
-          ? _value.minimumOsVersion
-          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
-              as num?,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$IOSPlatformConstraintsStorageV3Impl
-    extends _IOSPlatformConstraintsStorageV3 {
-  const _$IOSPlatformConstraintsStorageV3Impl({required this.minimumOsVersion})
-      : super._();
-
-  factory _$IOSPlatformConstraintsStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$IOSPlatformConstraintsStorageV3ImplFromJson(json);
-
-  @override
-  final num? minimumOsVersion;
-
-  @override
-  String toString() {
-    return 'IOSPlatformConstraintsStorageV3(minimumOsVersion: $minimumOsVersion)';
-  }
+  /// Serializes this IOSPlatformConstraintsStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$IOSPlatformConstraintsStorageV3Impl &&
+            other is IOSPlatformConstraintsStorageV3 &&
             (identical(other.minimumOsVersion, minimumOsVersion) ||
                 other.minimumOsVersion == minimumOsVersion));
   }
@@ -141,197 +42,153 @@ class _$IOSPlatformConstraintsStorageV3Impl
   @override
   int get hashCode => Object.hash(runtimeType, minimumOsVersion);
 
-  /// Create a copy of IOSPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$IOSPlatformConstraintsStorageV3ImplCopyWith<
-          _$IOSPlatformConstraintsStorageV3Impl>
-      get copyWith => __$$IOSPlatformConstraintsStorageV3ImplCopyWithImpl<
-          _$IOSPlatformConstraintsStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$IOSPlatformConstraintsStorageV3ImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _IOSPlatformConstraintsStorageV3
-    extends IOSPlatformConstraintsStorageV3 {
-  const factory _IOSPlatformConstraintsStorageV3(
-          {required final num? minimumOsVersion}) =
-      _$IOSPlatformConstraintsStorageV3Impl;
-  const _IOSPlatformConstraintsStorageV3._() : super._();
-
-  factory _IOSPlatformConstraintsStorageV3.fromJson(Map<String, dynamic> json) =
-      _$IOSPlatformConstraintsStorageV3Impl.fromJson;
-
-  @override
-  num? get minimumOsVersion;
-
-  /// Create a copy of IOSPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$IOSPlatformConstraintsStorageV3ImplCopyWith<
-          _$IOSPlatformConstraintsStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-AndroidPlatformConstraintsStorageV3
-    _$AndroidPlatformConstraintsStorageV3FromJson(Map<String, dynamic> json) {
-  return _AndroidPlatformConstraintsStorageV3.fromJson(json);
-}
-
-/// @nodoc
-mixin _$AndroidPlatformConstraintsStorageV3 {
-  int? get minSdkVersion => throw _privateConstructorUsedError;
-  int? get compileSdkVersion => throw _privateConstructorUsedError;
-  int? get targetSdkVersion => throw _privateConstructorUsedError;
-
-  /// Serializes this AndroidPlatformConstraintsStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of AndroidPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $AndroidPlatformConstraintsStorageV3CopyWith<
-          AndroidPlatformConstraintsStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory $AndroidPlatformConstraintsStorageV3CopyWith(
-          AndroidPlatformConstraintsStorageV3 value,
-          $Res Function(AndroidPlatformConstraintsStorageV3) then) =
-      _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-          AndroidPlatformConstraintsStorageV3>;
-  @useResult
-  $Res call(
-      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
-}
-
-/// @nodoc
-class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        $Val extends AndroidPlatformConstraintsStorageV3>
-    implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
-  _$AndroidPlatformConstraintsStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of AndroidPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? minSdkVersion = freezed,
-    Object? compileSdkVersion = freezed,
-    Object? targetSdkVersion = freezed,
-  }) {
-    return _then(_value.copyWith(
-      minSdkVersion: freezed == minSdkVersion
-          ? _value.minSdkVersion
-          : minSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      compileSdkVersion: freezed == compileSdkVersion
-          ? _value.compileSdkVersion
-          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      targetSdkVersion: freezed == targetSdkVersion
-          ? _value.targetSdkVersion
-          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-    ) as $Val);
+  String toString() {
+    return 'IOSPlatformConstraintsStorageV3(minimumOsVersion: $minimumOsVersion)';
   }
 }
 
 /// @nodoc
-abstract class _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<$Res>
-    implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
-  factory _$$AndroidPlatformConstraintsStorageV3ImplCopyWith(
-          _$AndroidPlatformConstraintsStorageV3Impl value,
-          $Res Function(_$AndroidPlatformConstraintsStorageV3Impl) then) =
-      __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
+  factory $IOSPlatformConstraintsStorageV3CopyWith(
+          IOSPlatformConstraintsStorageV3 value,
+          $Res Function(IOSPlatformConstraintsStorageV3) _then) =
+      _$IOSPlatformConstraintsStorageV3CopyWithImpl;
   @useResult
-  $Res call(
-      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
+  $Res call({num? minimumOsVersion});
 }
 
 /// @nodoc
-class __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<$Res>
-    extends _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res,
-        _$AndroidPlatformConstraintsStorageV3Impl>
-    implements _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<$Res> {
-  __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl(
-      _$AndroidPlatformConstraintsStorageV3Impl _value,
-      $Res Function(_$AndroidPlatformConstraintsStorageV3Impl) _then)
-      : super(_value, _then);
+class _$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
+  _$IOSPlatformConstraintsStorageV3CopyWithImpl(this._self, this._then);
 
-  /// Create a copy of AndroidPlatformConstraintsStorageV3
+  final IOSPlatformConstraintsStorageV3 _self;
+  final $Res Function(IOSPlatformConstraintsStorageV3) _then;
+
+  /// Create a copy of IOSPlatformConstraintsStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? minSdkVersion = freezed,
-    Object? compileSdkVersion = freezed,
-    Object? targetSdkVersion = freezed,
+    Object? minimumOsVersion = freezed,
   }) {
-    return _then(_$AndroidPlatformConstraintsStorageV3Impl(
-      minSdkVersion: freezed == minSdkVersion
-          ? _value.minSdkVersion
-          : minSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      compileSdkVersion: freezed == compileSdkVersion
-          ? _value.compileSdkVersion
-          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
-      targetSdkVersion: freezed == targetSdkVersion
-          ? _value.targetSdkVersion
-          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
-              as int?,
+    return _then(_self.copyWith(
+      minimumOsVersion: freezed == minimumOsVersion
+          ? _self.minimumOsVersion
+          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
+              as num?,
     ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
-class _$AndroidPlatformConstraintsStorageV3Impl
-    extends _AndroidPlatformConstraintsStorageV3 {
-  const _$AndroidPlatformConstraintsStorageV3Impl(
-      {required this.minSdkVersion,
-      required this.compileSdkVersion,
-      required this.targetSdkVersion})
+class _IOSPlatformConstraintsStorageV3 extends IOSPlatformConstraintsStorageV3 {
+  const _IOSPlatformConstraintsStorageV3({required this.minimumOsVersion})
       : super._();
-
-  factory _$AndroidPlatformConstraintsStorageV3Impl.fromJson(
+  factory _IOSPlatformConstraintsStorageV3.fromJson(
           Map<String, dynamic> json) =>
-      _$$AndroidPlatformConstraintsStorageV3ImplFromJson(json);
+      _$IOSPlatformConstraintsStorageV3FromJson(json);
 
   @override
-  final int? minSdkVersion;
+  final num? minimumOsVersion;
+
+  /// Create a copy of IOSPlatformConstraintsStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  final int? compileSdkVersion;
-  @override
-  final int? targetSdkVersion;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$IOSPlatformConstraintsStorageV3CopyWith<_IOSPlatformConstraintsStorageV3>
+      get copyWith => __$IOSPlatformConstraintsStorageV3CopyWithImpl<
+          _IOSPlatformConstraintsStorageV3>(this, _$identity);
 
   @override
-  String toString() {
-    return 'AndroidPlatformConstraintsStorageV3(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
+  Map<String, dynamic> toJson() {
+    return _$IOSPlatformConstraintsStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$AndroidPlatformConstraintsStorageV3Impl &&
+            other is _IOSPlatformConstraintsStorageV3 &&
+            (identical(other.minimumOsVersion, minimumOsVersion) ||
+                other.minimumOsVersion == minimumOsVersion));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, minimumOsVersion);
+
+  @override
+  String toString() {
+    return 'IOSPlatformConstraintsStorageV3(minimumOsVersion: $minimumOsVersion)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$IOSPlatformConstraintsStorageV3CopyWith<$Res>
+    implements $IOSPlatformConstraintsStorageV3CopyWith<$Res> {
+  factory _$IOSPlatformConstraintsStorageV3CopyWith(
+          _IOSPlatformConstraintsStorageV3 value,
+          $Res Function(_IOSPlatformConstraintsStorageV3) _then) =
+      __$IOSPlatformConstraintsStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call({num? minimumOsVersion});
+}
+
+/// @nodoc
+class __$IOSPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    implements _$IOSPlatformConstraintsStorageV3CopyWith<$Res> {
+  __$IOSPlatformConstraintsStorageV3CopyWithImpl(this._self, this._then);
+
+  final _IOSPlatformConstraintsStorageV3 _self;
+  final $Res Function(_IOSPlatformConstraintsStorageV3) _then;
+
+  /// Create a copy of IOSPlatformConstraintsStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? minimumOsVersion = freezed,
+  }) {
+    return _then(_IOSPlatformConstraintsStorageV3(
+      minimumOsVersion: freezed == minimumOsVersion
+          ? _self.minimumOsVersion
+          : minimumOsVersion // ignore: cast_nullable_to_non_nullable
+              as num?,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$AndroidPlatformConstraintsStorageV3 {
+  int? get minSdkVersion;
+  int? get compileSdkVersion;
+  int? get targetSdkVersion;
+
+  /// Create a copy of AndroidPlatformConstraintsStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $AndroidPlatformConstraintsStorageV3CopyWith<
+          AndroidPlatformConstraintsStorageV3>
+      get copyWith => _$AndroidPlatformConstraintsStorageV3CopyWithImpl<
+              AndroidPlatformConstraintsStorageV3>(
+          this as AndroidPlatformConstraintsStorageV3, _$identity);
+
+  /// Serializes this AndroidPlatformConstraintsStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is AndroidPlatformConstraintsStorageV3 &&
             (identical(other.minSdkVersion, minSdkVersion) ||
                 other.minSdkVersion == minSdkVersion) &&
             (identical(other.compileSdkVersion, compileSdkVersion) ||
@@ -345,49 +202,163 @@ class _$AndroidPlatformConstraintsStorageV3Impl
   int get hashCode => Object.hash(
       runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
 
-  /// Create a copy of AndroidPlatformConstraintsStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<
-          _$AndroidPlatformConstraintsStorageV3Impl>
-      get copyWith => __$$AndroidPlatformConstraintsStorageV3ImplCopyWithImpl<
-          _$AndroidPlatformConstraintsStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$AndroidPlatformConstraintsStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'AndroidPlatformConstraintsStorageV3(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
   }
 }
 
-abstract class _AndroidPlatformConstraintsStorageV3
+/// @nodoc
+abstract mixin class $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
+  factory $AndroidPlatformConstraintsStorageV3CopyWith(
+          AndroidPlatformConstraintsStorageV3 value,
+          $Res Function(AndroidPlatformConstraintsStorageV3) _then) =
+      _$AndroidPlatformConstraintsStorageV3CopyWithImpl;
+  @useResult
+  $Res call(
+      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
+}
+
+/// @nodoc
+class _$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
+  _$AndroidPlatformConstraintsStorageV3CopyWithImpl(this._self, this._then);
+
+  final AndroidPlatformConstraintsStorageV3 _self;
+  final $Res Function(AndroidPlatformConstraintsStorageV3) _then;
+
+  /// Create a copy of AndroidPlatformConstraintsStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? minSdkVersion = freezed,
+    Object? compileSdkVersion = freezed,
+    Object? targetSdkVersion = freezed,
+  }) {
+    return _then(_self.copyWith(
+      minSdkVersion: freezed == minSdkVersion
+          ? _self.minSdkVersion
+          : minSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      compileSdkVersion: freezed == compileSdkVersion
+          ? _self.compileSdkVersion
+          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      targetSdkVersion: freezed == targetSdkVersion
+          ? _self.targetSdkVersion
+          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _AndroidPlatformConstraintsStorageV3
     extends AndroidPlatformConstraintsStorageV3 {
-  const factory _AndroidPlatformConstraintsStorageV3(
-          {required final int? minSdkVersion,
-          required final int? compileSdkVersion,
-          required final int? targetSdkVersion}) =
-      _$AndroidPlatformConstraintsStorageV3Impl;
-  const _AndroidPlatformConstraintsStorageV3._() : super._();
-
+  const _AndroidPlatformConstraintsStorageV3(
+      {required this.minSdkVersion,
+      required this.compileSdkVersion,
+      required this.targetSdkVersion})
+      : super._();
   factory _AndroidPlatformConstraintsStorageV3.fromJson(
-          Map<String, dynamic> json) =
-      _$AndroidPlatformConstraintsStorageV3Impl.fromJson;
+          Map<String, dynamic> json) =>
+      _$AndroidPlatformConstraintsStorageV3FromJson(json);
 
   @override
-  int? get minSdkVersion;
+  final int? minSdkVersion;
   @override
-  int? get compileSdkVersion;
+  final int? compileSdkVersion;
   @override
-  int? get targetSdkVersion;
+  final int? targetSdkVersion;
 
   /// Create a copy of AndroidPlatformConstraintsStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$AndroidPlatformConstraintsStorageV3ImplCopyWith<
-          _$AndroidPlatformConstraintsStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$AndroidPlatformConstraintsStorageV3CopyWith<
+          _AndroidPlatformConstraintsStorageV3>
+      get copyWith => __$AndroidPlatformConstraintsStorageV3CopyWithImpl<
+          _AndroidPlatformConstraintsStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$AndroidPlatformConstraintsStorageV3ToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _AndroidPlatformConstraintsStorageV3 &&
+            (identical(other.minSdkVersion, minSdkVersion) ||
+                other.minSdkVersion == minSdkVersion) &&
+            (identical(other.compileSdkVersion, compileSdkVersion) ||
+                other.compileSdkVersion == compileSdkVersion) &&
+            (identical(other.targetSdkVersion, targetSdkVersion) ||
+                other.targetSdkVersion == targetSdkVersion));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, minSdkVersion, compileSdkVersion, targetSdkVersion);
+
+  @override
+  String toString() {
+    return 'AndroidPlatformConstraintsStorageV3(minSdkVersion: $minSdkVersion, compileSdkVersion: $compileSdkVersion, targetSdkVersion: $targetSdkVersion)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$AndroidPlatformConstraintsStorageV3CopyWith<$Res>
+    implements $AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
+  factory _$AndroidPlatformConstraintsStorageV3CopyWith(
+          _AndroidPlatformConstraintsStorageV3 value,
+          $Res Function(_AndroidPlatformConstraintsStorageV3) _then) =
+      __$AndroidPlatformConstraintsStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int? minSdkVersion, int? compileSdkVersion, int? targetSdkVersion});
+}
+
+/// @nodoc
+class __$AndroidPlatformConstraintsStorageV3CopyWithImpl<$Res>
+    implements _$AndroidPlatformConstraintsStorageV3CopyWith<$Res> {
+  __$AndroidPlatformConstraintsStorageV3CopyWithImpl(this._self, this._then);
+
+  final _AndroidPlatformConstraintsStorageV3 _self;
+  final $Res Function(_AndroidPlatformConstraintsStorageV3) _then;
+
+  /// Create a copy of AndroidPlatformConstraintsStorageV3
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? minSdkVersion = freezed,
+    Object? compileSdkVersion = freezed,
+    Object? targetSdkVersion = freezed,
+  }) {
+    return _then(_AndroidPlatformConstraintsStorageV3(
+      minSdkVersion: freezed == minSdkVersion
+          ? _self.minSdkVersion
+          : minSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      compileSdkVersion: freezed == compileSdkVersion
+          ? _self.compileSdkVersion
+          : compileSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+      targetSdkVersion: freezed == targetSdkVersion
+          ? _self.targetSdkVersion
+          : targetSdkVersion // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/src/storage/v3/platform_constraints_storage_v3.g.dart
+++ b/lib/src/storage/v3/platform_constraints_storage_v3.g.dart
@@ -8,29 +8,28 @@ part of 'platform_constraints_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$IOSPlatformConstraintsStorageV3Impl
-    _$$IOSPlatformConstraintsStorageV3ImplFromJson(Map<String, dynamic> json) =>
-        _$IOSPlatformConstraintsStorageV3Impl(
-          minimumOsVersion: json['minimumOsVersion'] as num?,
-        );
+_IOSPlatformConstraintsStorageV3 _$IOSPlatformConstraintsStorageV3FromJson(
+        Map<String, dynamic> json) =>
+    _IOSPlatformConstraintsStorageV3(
+      minimumOsVersion: json['minimumOsVersion'] as num?,
+    );
 
-Map<String, dynamic> _$$IOSPlatformConstraintsStorageV3ImplToJson(
-        _$IOSPlatformConstraintsStorageV3Impl instance) =>
+Map<String, dynamic> _$IOSPlatformConstraintsStorageV3ToJson(
+        _IOSPlatformConstraintsStorageV3 instance) =>
     <String, dynamic>{
       'minimumOsVersion': instance.minimumOsVersion,
     };
 
-_$AndroidPlatformConstraintsStorageV3Impl
-    _$$AndroidPlatformConstraintsStorageV3ImplFromJson(
-            Map<String, dynamic> json) =>
-        _$AndroidPlatformConstraintsStorageV3Impl(
+_AndroidPlatformConstraintsStorageV3
+    _$AndroidPlatformConstraintsStorageV3FromJson(Map<String, dynamic> json) =>
+        _AndroidPlatformConstraintsStorageV3(
           minSdkVersion: (json['minSdkVersion'] as num?)?.toInt(),
           compileSdkVersion: (json['compileSdkVersion'] as num?)?.toInt(),
           targetSdkVersion: (json['targetSdkVersion'] as num?)?.toInt(),
         );
 
-Map<String, dynamic> _$$AndroidPlatformConstraintsStorageV3ImplToJson(
-        _$AndroidPlatformConstraintsStorageV3Impl instance) =>
+Map<String, dynamic> _$AndroidPlatformConstraintsStorageV3ToJson(
+        _AndroidPlatformConstraintsStorageV3 instance) =>
     <String, dynamic>{
       'minSdkVersion': instance.minSdkVersion,
       'compileSdkVersion': instance.compileSdkVersion,

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.dart
@@ -7,7 +7,8 @@ part 'type_alias_declaration_storage_v3.g.dart';
 
 /// represents a found FieldDeclaration
 @freezed
-class TypeAliasDeclarationStorageV3 with _$TypeAliasDeclarationStorageV3 {
+sealed class TypeAliasDeclarationStorageV3
+    with _$TypeAliasDeclarationStorageV3 {
   const TypeAliasDeclarationStorageV3._();
 
   const factory TypeAliasDeclarationStorageV3({

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.freezed.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
@@ -9,112 +10,71 @@ part of 'type_alias_declaration_storage_v3.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-TypeAliasDeclarationStorageV3 _$TypeAliasDeclarationStorageV3FromJson(
-    Map<String, dynamic> json) {
-  return _TypeAliasDeclarationStorageV3.fromJson(json);
-}
 
 /// @nodoc
 mixin _$TypeAliasDeclarationStorageV3 {
-  String get name => throw _privateConstructorUsedError;
-  String get aliasedTypeName => throw _privateConstructorUsedError;
-  bool get isDeprecated => throw _privateConstructorUsedError;
-  bool get isExperimental => throw _privateConstructorUsedError;
-  Set<String> get entryPoints => throw _privateConstructorUsedError;
-  String get relativePath => throw _privateConstructorUsedError;
-
-  /// Serializes this TypeAliasDeclarationStorageV3 to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get name;
+  String get aliasedTypeName;
+  bool get isDeprecated;
+  bool get isExperimental;
+  Set<String> get entryPoints;
+  String get relativePath;
 
   /// Create a copy of TypeAliasDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $TypeAliasDeclarationStorageV3CopyWith<TypeAliasDeclarationStorageV3>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
-  factory $TypeAliasDeclarationStorageV3CopyWith(
-          TypeAliasDeclarationStorageV3 value,
-          $Res Function(TypeAliasDeclarationStorageV3) then) =
-      _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-          TypeAliasDeclarationStorageV3>;
-  @useResult
-  $Res call(
-      {String name,
-      String aliasedTypeName,
-      bool isDeprecated,
-      bool isExperimental,
-      Set<String> entryPoints,
-      String relativePath});
-}
-
-/// @nodoc
-class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-        $Val extends TypeAliasDeclarationStorageV3>
-    implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
-  _$TypeAliasDeclarationStorageV3CopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of TypeAliasDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $TypeAliasDeclarationStorageV3CopyWith<TypeAliasDeclarationStorageV3>
+      get copyWith => _$TypeAliasDeclarationStorageV3CopyWithImpl<
+              TypeAliasDeclarationStorageV3>(
+          this as TypeAliasDeclarationStorageV3, _$identity);
+
+  /// Serializes this TypeAliasDeclarationStorageV3 to a JSON map.
+  Map<String, dynamic> toJson();
+
   @override
-  $Res call({
-    Object? name = null,
-    Object? aliasedTypeName = null,
-    Object? isDeprecated = null,
-    Object? isExperimental = null,
-    Object? entryPoints = null,
-    Object? relativePath = null,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      aliasedTypeName: null == aliasedTypeName
-          ? _value.aliasedTypeName
-          : aliasedTypeName // ignore: cast_nullable_to_non_nullable
-              as String,
-      isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
-          : isDeprecated // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isExperimental: null == isExperimental
-          ? _value.isExperimental
-          : isExperimental // ignore: cast_nullable_to_non_nullable
-              as bool,
-      entryPoints: null == entryPoints
-          ? _value.entryPoints
-          : entryPoints // ignore: cast_nullable_to_non_nullable
-              as Set<String>,
-      relativePath: null == relativePath
-          ? _value.relativePath
-          : relativePath // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is TypeAliasDeclarationStorageV3 &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.aliasedTypeName, aliasedTypeName) ||
+                other.aliasedTypeName == aliasedTypeName) &&
+            (identical(other.isDeprecated, isDeprecated) ||
+                other.isDeprecated == isDeprecated) &&
+            (identical(other.isExperimental, isExperimental) ||
+                other.isExperimental == isExperimental) &&
+            const DeepCollectionEquality()
+                .equals(other.entryPoints, entryPoints) &&
+            (identical(other.relativePath, relativePath) ||
+                other.relativePath == relativePath));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      name,
+      aliasedTypeName,
+      isDeprecated,
+      isExperimental,
+      const DeepCollectionEquality().hash(entryPoints),
+      relativePath);
+
+  @override
+  String toString() {
+    return 'TypeAliasDeclarationStorageV3(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
 /// @nodoc
-abstract class _$$TypeAliasDeclarationStorageV3ImplCopyWith<$Res>
-    implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
-  factory _$$TypeAliasDeclarationStorageV3ImplCopyWith(
-          _$TypeAliasDeclarationStorageV3Impl value,
-          $Res Function(_$TypeAliasDeclarationStorageV3Impl) then) =
-      __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $TypeAliasDeclarationStorageV3CopyWith<$Res> {
+  factory $TypeAliasDeclarationStorageV3CopyWith(
+          TypeAliasDeclarationStorageV3 value,
+          $Res Function(TypeAliasDeclarationStorageV3) _then) =
+      _$TypeAliasDeclarationStorageV3CopyWithImpl;
   @useResult
   $Res call(
       {String name,
@@ -126,14 +86,12 @@ abstract class _$$TypeAliasDeclarationStorageV3ImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>
-    extends _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res,
-        _$TypeAliasDeclarationStorageV3Impl>
-    implements _$$TypeAliasDeclarationStorageV3ImplCopyWith<$Res> {
-  __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl(
-      _$TypeAliasDeclarationStorageV3Impl _value,
-      $Res Function(_$TypeAliasDeclarationStorageV3Impl) _then)
-      : super(_value, _then);
+class _$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
+    implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
+  _$TypeAliasDeclarationStorageV3CopyWithImpl(this._self, this._then);
+
+  final TypeAliasDeclarationStorageV3 _self;
+  final $Res Function(TypeAliasDeclarationStorageV3) _then;
 
   /// Create a copy of TypeAliasDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
@@ -147,29 +105,29 @@ class __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>
     Object? entryPoints = null,
     Object? relativePath = null,
   }) {
-    return _then(_$TypeAliasDeclarationStorageV3Impl(
+    return _then(_self.copyWith(
       name: null == name
-          ? _value.name
+          ? _self.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
       aliasedTypeName: null == aliasedTypeName
-          ? _value.aliasedTypeName
+          ? _self.aliasedTypeName
           : aliasedTypeName // ignore: cast_nullable_to_non_nullable
               as String,
       isDeprecated: null == isDeprecated
-          ? _value.isDeprecated
+          ? _self.isDeprecated
           : isDeprecated // ignore: cast_nullable_to_non_nullable
               as bool,
       isExperimental: null == isExperimental
-          ? _value.isExperimental
+          ? _self.isExperimental
           : isExperimental // ignore: cast_nullable_to_non_nullable
               as bool,
       entryPoints: null == entryPoints
-          ? _value._entryPoints
+          ? _self.entryPoints
           : entryPoints // ignore: cast_nullable_to_non_nullable
               as Set<String>,
       relativePath: null == relativePath
-          ? _value.relativePath
+          ? _self.relativePath
           : relativePath // ignore: cast_nullable_to_non_nullable
               as String,
     ));
@@ -178,9 +136,8 @@ class __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$TypeAliasDeclarationStorageV3Impl
-    extends _TypeAliasDeclarationStorageV3 {
-  const _$TypeAliasDeclarationStorageV3Impl(
+class _TypeAliasDeclarationStorageV3 extends TypeAliasDeclarationStorageV3 {
+  const _TypeAliasDeclarationStorageV3(
       {required this.name,
       required this.aliasedTypeName,
       required this.isDeprecated,
@@ -189,10 +146,8 @@ class _$TypeAliasDeclarationStorageV3Impl
       required this.relativePath})
       : _entryPoints = entryPoints,
         super._();
-
-  factory _$TypeAliasDeclarationStorageV3Impl.fromJson(
-          Map<String, dynamic> json) =>
-      _$$TypeAliasDeclarationStorageV3ImplFromJson(json);
+  factory _TypeAliasDeclarationStorageV3.fromJson(Map<String, dynamic> json) =>
+      _$TypeAliasDeclarationStorageV3FromJson(json);
 
   @override
   final String name;
@@ -213,16 +168,27 @@ class _$TypeAliasDeclarationStorageV3Impl
   @override
   final String relativePath;
 
+  /// Create a copy of TypeAliasDeclarationStorageV3
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'TypeAliasDeclarationStorageV3(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TypeAliasDeclarationStorageV3CopyWith<_TypeAliasDeclarationStorageV3>
+      get copyWith => __$TypeAliasDeclarationStorageV3CopyWithImpl<
+          _TypeAliasDeclarationStorageV3>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$TypeAliasDeclarationStorageV3ToJson(
+      this,
+    );
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TypeAliasDeclarationStorageV3Impl &&
+            other is _TypeAliasDeclarationStorageV3 &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.aliasedTypeName, aliasedTypeName) ||
                 other.aliasedTypeName == aliasedTypeName) &&
@@ -247,57 +213,77 @@ class _$TypeAliasDeclarationStorageV3Impl
       const DeepCollectionEquality().hash(_entryPoints),
       relativePath);
 
-  /// Create a copy of TypeAliasDeclarationStorageV3
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$TypeAliasDeclarationStorageV3ImplCopyWith<
-          _$TypeAliasDeclarationStorageV3Impl>
-      get copyWith => __$$TypeAliasDeclarationStorageV3ImplCopyWithImpl<
-          _$TypeAliasDeclarationStorageV3Impl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$TypeAliasDeclarationStorageV3ImplToJson(
-      this,
-    );
+  String toString() {
+    return 'TypeAliasDeclarationStorageV3(name: $name, aliasedTypeName: $aliasedTypeName, isDeprecated: $isDeprecated, isExperimental: $isExperimental, entryPoints: $entryPoints, relativePath: $relativePath)';
   }
 }
 
-abstract class _TypeAliasDeclarationStorageV3
-    extends TypeAliasDeclarationStorageV3 {
-  const factory _TypeAliasDeclarationStorageV3(
-          {required final String name,
-          required final String aliasedTypeName,
-          required final bool isDeprecated,
-          required final bool isExperimental,
-          required final Set<String> entryPoints,
-          required final String relativePath}) =
-      _$TypeAliasDeclarationStorageV3Impl;
-  const _TypeAliasDeclarationStorageV3._() : super._();
+/// @nodoc
+abstract mixin class _$TypeAliasDeclarationStorageV3CopyWith<$Res>
+    implements $TypeAliasDeclarationStorageV3CopyWith<$Res> {
+  factory _$TypeAliasDeclarationStorageV3CopyWith(
+          _TypeAliasDeclarationStorageV3 value,
+          $Res Function(_TypeAliasDeclarationStorageV3) _then) =
+      __$TypeAliasDeclarationStorageV3CopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String name,
+      String aliasedTypeName,
+      bool isDeprecated,
+      bool isExperimental,
+      Set<String> entryPoints,
+      String relativePath});
+}
 
-  factory _TypeAliasDeclarationStorageV3.fromJson(Map<String, dynamic> json) =
-      _$TypeAliasDeclarationStorageV3Impl.fromJson;
+/// @nodoc
+class __$TypeAliasDeclarationStorageV3CopyWithImpl<$Res>
+    implements _$TypeAliasDeclarationStorageV3CopyWith<$Res> {
+  __$TypeAliasDeclarationStorageV3CopyWithImpl(this._self, this._then);
 
-  @override
-  String get name;
-  @override
-  String get aliasedTypeName;
-  @override
-  bool get isDeprecated;
-  @override
-  bool get isExperimental;
-  @override
-  Set<String> get entryPoints;
-  @override
-  String get relativePath;
+  final _TypeAliasDeclarationStorageV3 _self;
+  final $Res Function(_TypeAliasDeclarationStorageV3) _then;
 
   /// Create a copy of TypeAliasDeclarationStorageV3
   /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$TypeAliasDeclarationStorageV3ImplCopyWith<
-          _$TypeAliasDeclarationStorageV3Impl>
-      get copyWith => throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? name = null,
+    Object? aliasedTypeName = null,
+    Object? isDeprecated = null,
+    Object? isExperimental = null,
+    Object? entryPoints = null,
+    Object? relativePath = null,
+  }) {
+    return _then(_TypeAliasDeclarationStorageV3(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      aliasedTypeName: null == aliasedTypeName
+          ? _self.aliasedTypeName
+          : aliasedTypeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      isDeprecated: null == isDeprecated
+          ? _self.isDeprecated
+          : isDeprecated // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isExperimental: null == isExperimental
+          ? _self.isExperimental
+          : isExperimental // ignore: cast_nullable_to_non_nullable
+              as bool,
+      entryPoints: null == entryPoints
+          ? _self._entryPoints
+          : entryPoints // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      relativePath: null == relativePath
+          ? _self.relativePath
+          : relativePath // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
 }
+
+// dart format on

--- a/lib/src/storage/v3/type_alias_declaration_storage_v3.g.dart
+++ b/lib/src/storage/v3/type_alias_declaration_storage_v3.g.dart
@@ -8,21 +8,21 @@ part of 'type_alias_declaration_storage_v3.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$TypeAliasDeclarationStorageV3Impl
-    _$$TypeAliasDeclarationStorageV3ImplFromJson(Map<String, dynamic> json) =>
-        _$TypeAliasDeclarationStorageV3Impl(
-          name: json['name'] as String,
-          aliasedTypeName: json['aliasedTypeName'] as String,
-          isDeprecated: json['isDeprecated'] as bool,
-          isExperimental: json['isExperimental'] as bool,
-          entryPoints: (json['entryPoints'] as List<dynamic>)
-              .map((e) => e as String)
-              .toSet(),
-          relativePath: json['relativePath'] as String,
-        );
+_TypeAliasDeclarationStorageV3 _$TypeAliasDeclarationStorageV3FromJson(
+        Map<String, dynamic> json) =>
+    _TypeAliasDeclarationStorageV3(
+      name: json['name'] as String,
+      aliasedTypeName: json['aliasedTypeName'] as String,
+      isDeprecated: json['isDeprecated'] as bool,
+      isExperimental: json['isExperimental'] as bool,
+      entryPoints: (json['entryPoints'] as List<dynamic>)
+          .map((e) => e as String)
+          .toSet(),
+      relativePath: json['relativePath'] as String,
+    );
 
-Map<String, dynamic> _$$TypeAliasDeclarationStorageV3ImplToJson(
-        _$TypeAliasDeclarationStorageV3Impl instance) =>
+Map<String, dynamic> _$TypeAliasDeclarationStorageV3ToJson(
+        _TypeAliasDeclarationStorageV3 instance) =>
     <String, dynamic>{
       'name': instance.name,
       'aliasedTypeName': instance.aliasedTypeName,

--- a/lib/src/utils/naming_utils.dart
+++ b/lib/src/utils/naming_utils.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:analyzer/dart/element/element.dart';
 
 /// Utilities for naming things

--- a/lib/src/utils/string_utils.dart
+++ b/lib/src/utils/string_utils.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:io';
 
 import 'package:analyzer/dart/element/element.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   colorize: ^3.0.0
   colorize_lumberdash: ^3.0.0
   console: ^4.1.0
-  freezed_annotation: ^2.4.4
+  freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   lumberdash: ^3.0.0
   path: ^1.9.0
@@ -29,7 +29,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   flutter_lints: ^3.0.1
-  freezed: ^2.2.0
+  freezed: ^3.0.0
   json_serializable: ^6.3.1
   lints: ^3.0.0
   mocktail: ^1.0.4

--- a/test/integration_tests/diff/test_package_operators_test.dart
+++ b/test/integration_tests/diff/test_package_operators_test.dart
@@ -1,0 +1,47 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('test_package_operators', () {
+    late PackageApiAnalyzer packageAWithRecord;
+    late PackageApiAnalyzer packageAWithChangedRecord;
+
+    setUpAll(
+      () {
+        packageAWithRecord = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'operators',
+          'package_a_with_operators',
+        ));
+        // we test the same package against itself.
+        // We just want to know if the differ can handle two operators with the same name
+        packageAWithChangedRecord = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'operators',
+          'package_a_with_operators',
+        ));
+      },
+    );
+    group('having the - operator two times (unary and not)', () {
+      late PackageApiDiffResult diffResult;
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageAWithRecord.analyze(),
+          newApi: await packageAWithChangedRecord.analyze(),
+        );
+      });
+
+      test('does not crash', () {
+        expect(
+          diffResult.apiChanges,
+          isEmpty,
+        );
+      });
+    });
+  });
+}

--- a/test/test_packages/operators/package_a_with_operators/.gitignore
+++ b/test/test_packages/operators/package_a_with_operators/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/test/test_packages/operators/package_a_with_operators/CHANGELOG.md
+++ b/test/test_packages/operators/package_a_with_operators/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/operators/package_a_with_operators/README.md
+++ b/test/test_packages/operators/package_a_with_operators/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/test/test_packages/operators/package_a_with_operators/analysis_options.yaml
+++ b/test/test_packages/operators/package_a_with_operators/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/test/test_packages/operators/package_a_with_operators/lib/package_a.dart
+++ b/test/test_packages/operators/package_a_with_operators/lib/package_a.dart
@@ -1,0 +1,6 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library package_a;
+
+export 'src/class_a.dart';

--- a/test/test_packages/operators/package_a_with_operators/lib/src/class_a.dart
+++ b/test/test_packages/operators/package_a_with_operators/lib/src/class_a.dart
@@ -1,0 +1,23 @@
+class ClassA {
+  final int _value = 0;
+
+  ClassA({required int value = 0}) : _value = value;
+
+  operator +(ClassA other) {
+    return ClassA(
+      value: _value + other._value,
+    );
+  }
+
+  operator -(ClassA other) {
+    return ClassA(
+      value: _value - other._value,
+    );
+  }
+
+  operator -() {
+    return ClassA(
+      value: -_value,
+    );
+  }
+}

--- a/test/test_packages/operators/package_a_with_operators/pubspec.yaml
+++ b/test/test_packages/operators/package_a_with_operators/pubspec.yaml
@@ -1,0 +1,14 @@
+name: package_a
+description: A starting point for Dart libraries or applications.
+version: 1.1.0
+# repository: https://github.com/my_org/my_repo
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.21.0


### PR DESCRIPTION
This is just an example PR - the bug could be fixed differently probably.

There is one method in Dart with overloading, the operator `-` can be used as `a - b` or as `-a`. This leads to failures downstream, see for example [this workflow run](https://github.com/dart-lang/core/actions/runs/14634892224/job/41063857744?pr=883).


- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
