### PR TITLE
bumps Flutter version to 3.29.3

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.27.1",
+  "flutter": "3.29.3",
   "flavors": {}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
           channel: 'any'
           cache-path: '${{ runner.tool_cache }}/flutter-${{ needs.get_flutter_version.outputs.flutter-version }}-any'
 
-      - name: Verify formatting
-        run: dart format --set-exit-if-changed .
-
       - name: Install dependencies
         run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
 
       - name: Verify Builder have been run
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.27.1",
+  "dart.flutterSdkPath": ".fvm/versions/3.29.3",
   "dart.sdkPath": ".fvm/flutter_sdk/bin/cache/dart-sdk",
   "search.exclude": {
     "**/.fvm": true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,10 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  flutter_lints: ^3.0.1
+  flutter_lints: ^5.0.0
   freezed: ^3.0.0
   json_serializable: ^6.3.1
-  lints: ^3.0.0
+  lints: ^5.1.1
   mocktail: ^1.0.4
   test: ^1.21.4
 

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -240,58 +240,64 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
-    test('Can handle ffigen dependency overrides correctly (pub ref)',
-        () async {
-      final packageName = 'ffigen';
-      final packageVersion = '16.0.0';
-
-      final exitCode = await runner.run([
-        'extract',
-        '--force-use-flutter',
-        '--input',
-        'pub://$packageName/$packageVersion',
-      ]);
-      expect(exitCode, 0);
-    });
-    test('Can handle ffigen dependency overrides correctly (git ref)',
-        () async {
-      final gitUrl = 'https://github.com/dart-lang/native.git';
-      final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
-      final relativePath = 'pkgs/ffigen';
-
-      // create temporary directory
-      final tempDir = await Directory.systemTemp.createTemp();
-
-      try {
-        // clone repo
-        final resultClone = Process.runSync('git', [
-          'clone',
-          gitUrl,
-          tempDir.path,
-        ]);
-        assert(resultClone.exitCode == 0);
-
-        // checkout ref
-        final resultCheckout = Process.runSync(
-            'git',
-            [
-              'checkout',
-              gitRef,
-            ],
-            workingDirectory: tempDir.path);
-        assert(resultCheckout.exitCode == 0);
+    test(
+      'Can handle ffigen dependency overrides correctly (pub ref)',
+      () async {
+        final packageName = 'ffigen';
+        final packageVersion = '16.0.0';
 
         final exitCode = await runner.run([
           'extract',
           '--force-use-flutter',
           '--input',
-          '${tempDir.path}/$relativePath',
+          'pub://$packageName/$packageVersion',
         ]);
         expect(exitCode, 0);
-      } finally {
-        tempDir.deleteSync(recursive: true);
-      }
-    });
+      },
+      timeout: integrationTestTimeout,
+    );
+    test(
+      'Can handle ffigen dependency overrides correctly (git ref)',
+      () async {
+        final gitUrl = 'https://github.com/dart-lang/native.git';
+        final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
+        final relativePath = 'pkgs/ffigen';
+
+        // create temporary directory
+        final tempDir = await Directory.systemTemp.createTemp();
+
+        try {
+          // clone repo
+          final resultClone = Process.runSync('git', [
+            'clone',
+            gitUrl,
+            tempDir.path,
+          ]);
+          assert(resultClone.exitCode == 0);
+
+          // checkout ref
+          final resultCheckout = Process.runSync(
+              'git',
+              [
+                'checkout',
+                gitRef,
+              ],
+              workingDirectory: tempDir.path);
+          assert(resultCheckout.exitCode == 0);
+
+          final exitCode = await runner.run([
+            'extract',
+            '--force-use-flutter',
+            '--input',
+            '${tempDir.path}/$relativePath',
+          ]);
+          expect(exitCode, 0);
+        } finally {
+          tempDir.deleteSync(recursive: true);
+        }
+      },
+      timeout: integrationTestTimeout,
+    );
 
     test(
       'can handle packages in a workspace',

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -247,6 +247,7 @@ void main() {
 
       final exitCode = await runner.run([
         'extract',
+        '--force-use-flutter',
         '--input',
         'pub://$packageName/$packageVersion',
       ]);
@@ -282,6 +283,7 @@ void main() {
 
         final exitCode = await runner.run([
           'extract',
+          '--force-use-flutter',
           '--input',
           '${tempDir.path}/$relativePath',
         ]);


### PR DESCRIPTION
## Description
This PR bumps Flutter to 3.29.3 and also upgrade the lint dependencies

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
