### PR TITLE
chore: replace deprecated analyzer APIs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,12 @@
     "**/.fvm": true
   },
   "editor.formatOnSave": true,
-  "dart.lineLength": 80
+  "dart.lineLength": 80,
+  "cSpell.words": [
+    "devmil",
+    "hamsbrar",
+    "jonasfj",
+    "mocktail",
+    "mosuem"
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.21.0
+- chore: adapt to new analyzer API. This may break things
+
 ## Version 0.20.3
 - fix: unary and binary operators can have the same name and crashed dart_apitool
 

--- a/lib/src/analyze/exported_files_collector.dart
+++ b/lib/src/analyze/exported_files_collector.dart
@@ -1,7 +1,5 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/dart/element/visitor.dart';
+import 'package:analyzer/dart/element/element2.dart';
+import 'package:analyzer/dart/element/visitor2.dart';
 
 /// represents a file reference extracted from a dart source file
 class FileReference {
@@ -9,10 +7,10 @@ class FileReference {
   final String uri;
 
   /// library the reference comes from
-  final LibraryElement originLibrary;
+  final LibraryElement2 originLibrary;
 
   /// library the reference points to
-  final LibraryElement? referencedLibrary;
+  final LibraryElement2? referencedLibrary;
 
   /// list of show parameters for this reference
   final List<String> shownNames;
@@ -33,24 +31,27 @@ class FileReference {
 /// connector to collect exported files from an Element
 ///
 /// it will collect all encountered export elements and store them to [fileReferences]
-class ExportedFilesCollector extends RecursiveElementVisitor<void> {
+class ExportedFilesCollector extends RecursiveElementVisitor2<void> {
   final fileReferences = List<FileReference>.empty(growable: true);
 
   @override
-  visitLibraryExportElement(LibraryExportElement element) {
-    _addUri(
-      uri: element.uri,
-      originLibrary: element.library,
-      referencedLibrary: element.exportedLibrary,
-      combinators: element.combinators,
-    );
-    super.visitLibraryExportElement(element);
+  void visitLibraryElement(LibraryElement2 element) {
+    for (final libraryFragment in element.fragments) {
+      for (final exportedLibrary in libraryFragment.libraryExports2) {
+        _addUri(
+          uri: exportedLibrary.uri,
+          originLibrary: element,
+          referencedLibrary: exportedLibrary.exportedLibrary2,
+          combinators: exportedLibrary.combinators,
+        );
+      }
+    }
   }
 
   void _addUri({
     required DirectiveUri uri,
-    required LibraryElement originLibrary,
-    LibraryElement? referencedLibrary,
+    required LibraryElement2 originLibrary,
+    LibraryElement2? referencedLibrary,
     required List<NamespaceCombinator> combinators,
   }) {
     if (uri is DirectiveUriWithRelativeUriString) {

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -1,11 +1,11 @@
-// ignore_for_file: avoid_print, deprecated_member_use
+// ignore_for_file: avoid_print
 
 import 'dart:collection';
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/file_system/file_system.dart' hide File;
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:dart_apitool/api_tool.dart';
@@ -108,7 +108,7 @@ class PackageApiAnalyzer {
               rootPath: normalizedAbsoluteProjectPath,
               typeHierarchy: typeHierarchy,
             );
-            unitResult.libraryElement.accept(collector);
+            unitResult.libraryElement2.accept2(collector);
             final skippedInterfaces = <int>[];
             for (final cd in collector.interfaceDeclarations) {
               if (!collectedInterfaces.containsKey(cd.id)) {
@@ -234,7 +234,7 @@ class PackageApiAnalyzer {
           }
 
           final referencedFilesCollector = ExportedFilesCollector();
-          unitResult.libraryElement.accept(referencedFilesCollector);
+          unitResult.libraryElement2.accept2(referencedFilesCollector);
           for (final fileRef in referencedFilesCollector.fileReferences) {
             if (!_isInternalRef(
                 originLibrary: fileRef.originLibrary,
@@ -424,8 +424,8 @@ class PackageApiAnalyzer {
   }
 
   bool _isInternalRef(
-      {required LibraryElement originLibrary,
-      required LibraryElement? refLibrary}) {
+      {required LibraryElement2 originLibrary,
+      required LibraryElement2? refLibrary}) {
     if (refLibrary == null) {
       return true;
     }

--- a/lib/src/diff/package_api_differ.dart
+++ b/lib/src/diff/package_api_differ.dart
@@ -933,11 +933,11 @@ class PackageApiDiffer {
         newField.isReadable,
         context,
         newField,
-        'Readablility changed. ${oldField.isReadable} -> ${newField.isReadable}',
+        'Readability changed. ${oldField.isReadable} -> ${newField.isReadable}',
         changes,
         changeCode: ApiChangeCode.cf07,
         isExperimental: isExperimental,
-        // the change is compatible if the field gained readablility
+        // the change is compatible if the field gained readability
         isCompatibleChange: newField.isReadable,
       );
       _comparePropertiesAndAddChange(

--- a/lib/src/model/internal/internal_executable_declaration.dart
+++ b/lib/src/model/internal/internal_executable_declaration.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 import '../executable_declaration.dart';
 import 'internal_declaration.dart';
@@ -46,33 +44,36 @@ class InternalExecutableDeclaration implements InternalDeclaration {
   });
 
   InternalExecutableDeclaration.fromExecutableElement(
-    ExecutableElement executableElement, {
+    ExecutableElement2 executableElement, {
     String? namespace,
     required String rootPath,
   }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(executableElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              executableElement.enclosingElement3),
+              executableElement.enclosingElement2),
           returnTypeName: executableElement.returnType.getDisplayString(),
           returnTypeFullLibraryName:
-              executableElement.returnType.element?.librarySource?.fullName,
+              executableElement.returnType.element3?.library2?.uri.toString(),
           // This is a fix for the only method overloading in Dart the `-` operator
-          name: executableElement.isOperator
-              ? (executableElement.parameters.isEmpty ? 'unary' : 'nonunary') +
-                  executableElement.displayName
-              : executableElement.displayName,
+          name: (executableElement is MethodElement2 &&
+                  executableElement.isOperator)
+              ? (executableElement.formalParameters.isEmpty
+                      ? 'unary'
+                      : 'binary') +
+                  (executableElement.name3 ?? executableElement.displayName)
+              : executableElement.name3 ?? executableElement.displayName,
           namespace: namespace,
-          isDeprecated: executableElement.hasDeprecated,
+          isDeprecated: executableElement.metadata2.hasDeprecated,
           isExperimental:
               InternalDeclarationUtils.hasExperimental(executableElement),
           parameters: _computeParameterList(
-            executableElement.parameters,
+            executableElement.formalParameters,
             InternalDeclarationUtils.getRelativePath(
                 rootPath, executableElement),
             rootPath,
           ),
           typeParameterNames:
-              _computeTypeParameters(executableElement.typeParameters),
+              _computeTypeParameters(executableElement.typeParameters2),
           type: _computeExecutableType(executableElement),
           isStatic: executableElement.isStatic,
           entryPoints: {},
@@ -99,33 +100,33 @@ class InternalExecutableDeclaration implements InternalDeclaration {
 
   /// retrieves the type of executable from the given [executableElement]
   static ExecutableType _computeExecutableType(
-      ExecutableElement executableElement) {
-    if (executableElement is ConstructorElement) {
+      ExecutableElement2 executableElement) {
+    if (executableElement is ConstructorElement2) {
       return ExecutableType.constructor;
     }
     return ExecutableType.method;
   }
 
   static List<ExecutableParameterDeclaration> _computeParameterList(
-      List<ParameterElement> parameterElementList,
+      List<FormalParameterElement> parameterElementList,
       String relativePath,
       String rootPath) {
     return parameterElementList
         .map((e) => ExecutableParameterDeclaration(
               isRequired: e.isRequired,
               isNamed: e.isNamed,
-              name: e.name,
-              isDeprecated: e.hasDeprecated,
+              name: e.name3 ?? e.displayName,
+              isDeprecated: e.metadata2.hasDeprecated,
               isExperimental: InternalDeclarationUtils.hasExperimental(e),
               typeName: e.type.getDisplayString(),
-              typeFullLibraryName: e.type.element?.librarySource?.fullName,
+              typeFullLibraryName: e.type.element3?.library2?.uri.toString(),
               relativePath: relativePath,
             ))
         .toList();
   }
 
   static List<String> _computeTypeParameters(
-      List<TypeParameterElement> paramList) {
-    return paramList.map((pe) => pe.name).toList();
+      List<TypeParameterElement2> paramList) {
+    return paramList.map((pe) => pe.name3 ?? pe.displayName).toList();
   }
 }

--- a/lib/src/model/internal/internal_field_declaration.dart
+++ b/lib/src/model/internal/internal_field_declaration.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 import '../field_declaration.dart';
 import 'internal_declaration.dart';
@@ -46,19 +44,19 @@ class InternalFieldDeclaration implements InternalDeclaration {
   });
 
   InternalFieldDeclaration.fromPropertyInducingElement(
-    PropertyInducingElement fieldElement, {
+    PropertyInducingElement2 fieldElement, {
     String? namespace,
     required String rootPath,
   }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(fieldElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              fieldElement.enclosingElement3),
+              fieldElement.enclosingElement2),
           typeName: fieldElement.type.getDisplayString(),
           typeFullLibraryName:
-              fieldElement.type.element?.librarySource?.fullName,
-          name: fieldElement.name,
+              fieldElement.type.element3?.library2?.uri.toString(),
+          name: fieldElement.name3 ?? fieldElement.displayName,
           namespace: namespace,
-          isDeprecated: fieldElement.hasDeprecated,
+          isDeprecated: fieldElement.metadata2.hasDeprecated,
           isExperimental:
               InternalDeclarationUtils.hasExperimental(fieldElement),
           isStatic: fieldElement.isStatic,
@@ -66,8 +64,8 @@ class InternalFieldDeclaration implements InternalDeclaration {
           entryPoints: {},
           relativePath:
               InternalDeclarationUtils.getRelativePath(rootPath, fieldElement),
-          isReadable: fieldElement.getter != null,
-          isWriteable: fieldElement.setter != null,
+          isReadable: fieldElement.getter2 != null,
+          isWriteable: fieldElement.setter2 != null,
         );
 
   FieldDeclaration toFieldDeclaration() {

--- a/lib/src/model/internal/internal_interface_declaration.dart
+++ b/lib/src/model/internal/internal_interface_declaration.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 import '../interface_declaration.dart';
 import '../executable_declaration.dart';
@@ -55,24 +53,24 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
   });
 
   InternalInterfaceDeclaration.fromInterfaceElement(
-    InterfaceElement interfaceElement, {
+    InterfaceElement2 interfaceElement, {
     String? namespace,
     required String rootPath,
   }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(interfaceElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              interfaceElement.enclosingElement3),
-          name: interfaceElement.name,
+              interfaceElement.enclosingElement2),
+          name: interfaceElement.name3 ?? interfaceElement.displayName,
           namespace: namespace,
           isPrivate: interfaceElement.isPrivate,
-          isDeprecated: interfaceElement.hasDeprecated,
+          isDeprecated: interfaceElement.metadata2.hasDeprecated,
           isExperimental:
               InternalDeclarationUtils.hasExperimental(interfaceElement),
           isSealed: InternalDeclarationUtils.hasSealed(interfaceElement),
-          isAbstract:
-              (interfaceElement is ClassElement) && interfaceElement.isAbstract,
+          isAbstract: (interfaceElement is ClassElement2) &&
+              interfaceElement.isAbstract,
           typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
-              interfaceElement.typeParameters),
+              interfaceElement.typeParameters2),
           superTypeNames: InternalDeclarationUtils.computeSuperTypeNames(
               interfaceElement.allSupertypes),
           executableDeclarations: [],
@@ -81,29 +79,29 @@ class InternalInterfaceDeclaration implements InternalDeclaration {
           relativePath: InternalDeclarationUtils.getRelativePath(
               rootPath, interfaceElement),
           superClassIds: interfaceElement.allSupertypes
-              .map((e) => InternalDeclarationUtils.getIdFromElement(e.element))
+              .map((e) => InternalDeclarationUtils.getIdFromElement(e.element3))
               .nonNulls
               .toList(),
         );
 
   InternalInterfaceDeclaration.fromExtensionElement(
-    ExtensionElement extensionElement, {
+    ExtensionElement2 extensionElement, {
     String? namespace,
     required String rootPath,
   }) : this._(
           id: InternalDeclarationUtils.getIdFromElement(extensionElement)!,
           parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-              extensionElement.enclosingElement3),
-          name: extensionElement.name ?? extensionElement.displayName,
+              extensionElement.enclosingElement2),
+          name: extensionElement.name3 ?? extensionElement.displayName,
           namespace: namespace,
           isPrivate: extensionElement.isPrivate,
-          isDeprecated: extensionElement.hasDeprecated,
+          isDeprecated: extensionElement.metadata2.hasDeprecated,
           isExperimental:
               InternalDeclarationUtils.hasExperimental(extensionElement),
           isSealed: InternalDeclarationUtils.hasSealed(extensionElement),
           isAbstract: false,
           typeParameterNames: InternalDeclarationUtils.computeTypeParameters(
-              extensionElement.typeParameters),
+              extensionElement.typeParameters2),
           superTypeNames: const {},
           executableDeclarations: [],
           fieldDeclarations: [],

--- a/lib/src/model/internal/internal_type_alias_declaration.dart
+++ b/lib/src/model/internal/internal_type_alias_declaration.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:dart_apitool/src/model/internal/internal_declaration.dart';
 import 'package:dart_apitool/src/model/type_alias_declaration.dart';
 
@@ -36,17 +34,17 @@ class InternalTypeAliasDeclaration implements InternalDeclaration {
   });
 
   InternalTypeAliasDeclaration.fromTypeAliasElement(
-    TypeAliasElement typeAliasElement, {
+    TypeAliasElement2 typeAliasElement, {
     String? namespace,
     required String rootPath,
   }) : this._(
             id: InternalDeclarationUtils.getIdFromElement(typeAliasElement)!,
             parentClassId: InternalDeclarationUtils.getIdFromParentElement(
-                typeAliasElement.enclosingElement3),
-            name: typeAliasElement.name,
+                typeAliasElement.enclosingElement2),
+            name: typeAliasElement.name3 ?? typeAliasElement.displayName,
             namespace: namespace,
             aliasedTypeName: typeAliasElement.aliasedType.getDisplayString(),
-            isDeprecated: typeAliasElement.hasDeprecated,
+            isDeprecated: typeAliasElement.metadata2.hasDeprecated,
             isExperimental:
                 InternalDeclarationUtils.hasExperimental(typeAliasElement),
             entryPoints: {},

--- a/lib/src/model/internal/internal_type_usage.dart
+++ b/lib/src/model/internal/internal_type_usage.dart
@@ -1,6 +1,4 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:dart_apitool/src/model/internal/internal_declaration_utils.dart';
 
 import '../model.dart';
@@ -22,12 +20,13 @@ class InternalTypeUsage {
   /// creates an internal representation of a type usage
   /// from the given [kind] and [element]
   InternalTypeUsage.fromElement(
-      {required TypeUsageKind kind, required Element element})
+      {required TypeUsageKind kind, required Element2 element})
       : this._(
           kind: kind,
           referringElementName:
               InternalDeclarationUtils.getFullQualifiedNameFor(element),
-          isVisibleForTesting:
-              InternalDeclarationUtils.hasVisibleForTesting(element),
+          isVisibleForTesting: (element is Annotatable &&
+              InternalDeclarationUtils.hasVisibleForTesting(
+                  element as Annotatable)),
         );
 }

--- a/lib/src/utils/naming_utils.dart
+++ b/lib/src/utils/naming_utils.dart
@@ -1,13 +1,11 @@
-// ignore_for_file: deprecated_member_use
-
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 
 /// Utilities for naming things
 abstract class NamingUtils {
   /// calculates the full library path
   static String getFullLibraryPathFromElement({
-    required Element? element,
+    required Element2? element,
   }) {
-    return element?.librarySource?.fullName ?? '';
+    return element?.library2?.uri.toString() ?? '';
   }
 }

--- a/lib/src/utils/string_utils.dart
+++ b/lib/src/utils/string_utils.dart
@@ -1,8 +1,6 @@
-// ignore_for_file: deprecated_member_use
-
 import 'dart:io';
 
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:path/path.dart' as path;
 
 /// returns the type parameter suffix (like `<T>`)
@@ -14,7 +12,7 @@ String getTypeParameterSuffix(List<String> typeParameterNames) {
   return typeParameterSuffix;
 }
 
-String? getPackageNameFromLibrary(LibraryElement library) {
+String? getPackageNameFromLibrary(LibraryElement2 library) {
   String? packageName;
   packageName = _getPackageNameFromPackageUri(library.identifier);
   packageName ??= _getPackageNameFromFilePath(library.identifier);
@@ -52,7 +50,7 @@ String? _getPackageNameFromFilePath(String filePathOrUri) {
     }
   }
   // here we either didn't find a lib folder or the lib folder is not next to a pubspec.yaml
-  // so search for a pubspec.yaml regardles of the lib director
+  // so search for a pubspec.yaml regardless of the lib director
   for (int i = parts.length - 1; i > 0; i--) {
     if (_isPackageDirectory(path.joinAll(parts.take(i)))) {
       return parts[i - 1]; //we can do that as we stop as i>0}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.20.3-dev
+version: 0.21.0-dev
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -240,58 +240,64 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
-    test('Can handle ffigen dependency overrides correctly (pub ref)',
-        () async {
-      final packageName = 'ffigen';
-      final packageVersion = '16.0.0';
-
-      final exitCode = await runner.run([
-        'extract',
-        '--force-use-flutter',
-        '--input',
-        'pub://$packageName/$packageVersion',
-      ]);
-      expect(exitCode, 0);
-    });
-    test('Can handle ffigen dependency overrides correctly (git ref)',
-        () async {
-      final gitUrl = 'https://github.com/dart-lang/native.git';
-      final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
-      final relativePath = 'pkgs/ffigen';
-
-      // create temporary directory
-      final tempDir = await Directory.systemTemp.createTemp();
-
-      try {
-        // clone repo
-        final resultClone = Process.runSync('git', [
-          'clone',
-          gitUrl,
-          tempDir.path,
-        ]);
-        assert(resultClone.exitCode == 0);
-
-        // checkout ref
-        final resultCheckout = Process.runSync(
-            'git',
-            [
-              'checkout',
-              gitRef,
-            ],
-            workingDirectory: tempDir.path);
-        assert(resultCheckout.exitCode == 0);
+    test(
+      'Can handle ffigen dependency overrides correctly (pub ref)',
+      () async {
+        final packageName = 'ffigen';
+        final packageVersion = '16.0.0';
 
         final exitCode = await runner.run([
           'extract',
           '--force-use-flutter',
           '--input',
-          '${tempDir.path}/$relativePath',
+          'pub://$packageName/$packageVersion',
         ]);
         expect(exitCode, 0);
-      } finally {
-        tempDir.deleteSync(recursive: true);
-      }
-    });
+      },
+      timeout: integrationTestTimeout,
+    );
+    test(
+      'Can handle ffigen dependency overrides correctly (git ref)',
+      () async {
+        final gitUrl = 'https://github.com/dart-lang/native.git';
+        final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
+        final relativePath = 'pkgs/ffigen';
+
+        // create temporary directory
+        final tempDir = await Directory.systemTemp.createTemp();
+
+        try {
+          // clone repo
+          final resultClone = Process.runSync('git', [
+            'clone',
+            gitUrl,
+            tempDir.path,
+          ]);
+          assert(resultClone.exitCode == 0);
+
+          // checkout ref
+          final resultCheckout = Process.runSync(
+              'git',
+              [
+                'checkout',
+                gitRef,
+              ],
+              workingDirectory: tempDir.path);
+          assert(resultCheckout.exitCode == 0);
+
+          final exitCode = await runner.run([
+            'extract',
+            '--force-use-flutter',
+            '--input',
+            '${tempDir.path}/$relativePath',
+          ]);
+          expect(exitCode, 0);
+        } finally {
+          tempDir.deleteSync(recursive: true);
+        }
+      },
+      timeout: integrationTestTimeout,
+    );
 
     test(
       'can handle packages in a workspace',

--- a/test/integration_tests/cli/extract_command_test.dart
+++ b/test/integration_tests/cli/extract_command_test.dart
@@ -240,64 +240,58 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
-    test(
-      'Can handle ffigen dependency overrides correctly (pub ref)',
-      () async {
-        final packageName = 'ffigen';
-        final packageVersion = '16.0.0';
+    test('Can handle ffigen dependency overrides correctly (pub ref)',
+        () async {
+      final packageName = 'ffigen';
+      final packageVersion = '16.0.0';
+
+      final exitCode = await runner.run([
+        'extract',
+        '--force-use-flutter',
+        '--input',
+        'pub://$packageName/$packageVersion',
+      ]);
+      expect(exitCode, 0);
+    });
+    test('Can handle ffigen dependency overrides correctly (git ref)',
+        () async {
+      final gitUrl = 'https://github.com/dart-lang/native.git';
+      final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
+      final relativePath = 'pkgs/ffigen';
+
+      // create temporary directory
+      final tempDir = await Directory.systemTemp.createTemp();
+
+      try {
+        // clone repo
+        final resultClone = Process.runSync('git', [
+          'clone',
+          gitUrl,
+          tempDir.path,
+        ]);
+        assert(resultClone.exitCode == 0);
+
+        // checkout ref
+        final resultCheckout = Process.runSync(
+            'git',
+            [
+              'checkout',
+              gitRef,
+            ],
+            workingDirectory: tempDir.path);
+        assert(resultCheckout.exitCode == 0);
 
         final exitCode = await runner.run([
           'extract',
           '--force-use-flutter',
           '--input',
-          'pub://$packageName/$packageVersion',
+          '${tempDir.path}/$relativePath',
         ]);
         expect(exitCode, 0);
-      },
-      timeout: integrationTestTimeout,
-    );
-    test(
-      'Can handle ffigen dependency overrides correctly (git ref)',
-      () async {
-        final gitUrl = 'https://github.com/dart-lang/native.git';
-        final gitRef = 'cb477002e2d2559975d76165210eeca98821688d';
-        final relativePath = 'pkgs/ffigen';
-
-        // create temporary directory
-        final tempDir = await Directory.systemTemp.createTemp();
-
-        try {
-          // clone repo
-          final resultClone = Process.runSync('git', [
-            'clone',
-            gitUrl,
-            tempDir.path,
-          ]);
-          assert(resultClone.exitCode == 0);
-
-          // checkout ref
-          final resultCheckout = Process.runSync(
-              'git',
-              [
-                'checkout',
-                gitRef,
-              ],
-              workingDirectory: tempDir.path);
-          assert(resultCheckout.exitCode == 0);
-
-          final exitCode = await runner.run([
-            'extract',
-            '--force-use-flutter',
-            '--input',
-            '${tempDir.path}/$relativePath',
-          ]);
-          expect(exitCode, 0);
-        } finally {
-          tempDir.deleteSync(recursive: true);
-        }
-      },
-      timeout: integrationTestTimeout,
-    );
+      } finally {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
 
     test(
       'can handle packages in a workspace',


### PR DESCRIPTION
## Description
This PR replaces the deprecated analyzer API calls with the newer ones.
As this caused some behavior change and adaptions that go beyond just "renaming a method call" I decided to give that change a major version bump.

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [x] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [x] 🧹 Chore / Housekeeping
