### PR TITLE
Use intermediate pubspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.21.0
 - chore: adapt to new analyzer API. This may break things
+- tech: use different preparation approach for packages (wrapper package instead of copy & adapt)
 
 ## Version 0.20.3
 - fix: unary and binary operators can have the same name and crashed dart_apitool

--- a/lib/src/analyze/package_api_analyzer.dart
+++ b/lib/src/analyze/package_api_analyzer.dart
@@ -33,6 +33,7 @@ part 'package_api_analyzer.freezed.dart';
 class PackageApiAnalyzer {
   /// path to the package to analyze
   final String packagePath;
+  final String analyzerRootPath;
   final bool doAnalyzePlatformConstraints;
   final bool doConsiderNonSrcAsEntryPoints;
 
@@ -45,6 +46,7 @@ class PackageApiAnalyzer {
   /// [doConsiderNonSrcAsEntryPoints] defines if all files that are not in the lib/src subdirectory are considered as entry points. Otherwise only files directly in the lib subdirectory are considered as entry points.
   PackageApiAnalyzer({
     required this.packagePath,
+    required this.analyzerRootPath,
     this.doAnalyzePlatformConstraints = true,
     this.doConsiderNonSrcAsEntryPoints = false,
   }) {
@@ -62,6 +64,8 @@ class PackageApiAnalyzer {
   Future<PackageApi> analyze() async {
     final normalizedAbsoluteProjectPath =
         _getNormalizedAbsolutePath(packagePath);
+    final normalizedAbsoluteAnalyzerRootPath =
+        _getNormalizedAbsolutePath(analyzerRootPath);
 
     final yamlContent =
         await File(path.join(normalizedAbsoluteProjectPath, 'pubspec.yaml'))
@@ -74,7 +78,10 @@ class PackageApiAnalyzer {
         path.join(normalizedAbsoluteProjectPath, 'lib'));
 
     final contextCollection = _createAnalysisContextCollection(
-      path: normalizedAbsoluteProjectPath,
+      paths: [
+        normalizedAbsoluteProjectPath,
+        normalizedAbsoluteAnalyzerRootPath,
+      ],
       resourceProvider: resourceProvider,
     );
 
@@ -402,11 +409,11 @@ class PackageApiAnalyzer {
   }
 
   AnalysisContextCollection _createAnalysisContextCollection({
-    required String path,
+    required List<String> paths,
     ResourceProvider? resourceProvider,
   }) {
     AnalysisContextCollection collection = AnalysisContextCollection(
-      includedPaths: <String>[path],
+      includedPaths: paths,
       resourceProvider: resourceProvider ?? PhysicalResourceProvider.INSTANCE,
     );
     return collection;

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -1,3 +1,4 @@
 export 'commands/commands.dart';
 export 'package_ref.dart';
 export 'prepared_package_ref.dart';
+export 'dummy_ref_package.dart';

--- a/lib/src/cli/dummy_ref_package.dart
+++ b/lib/src/cli/dummy_ref_package.dart
@@ -1,0 +1,9 @@
+class DummyRefPackage {
+  final String referencedPackagePath;
+  final String tempDirectoryPath;
+
+  DummyRefPackage({
+    required this.referencedPackagePath,
+    required this.tempDirectoryPath,
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   path: ^1.9.0
   plist_parser: ^0.0.9
   pub_semver: ^2.1.4
-  pubspec_manager: ^1.0.0
   pubspec_parse: ^1.5.0
   stack: ^0.2.1
   tuple: ^2.0.0

--- a/test/integration_tests/cli/preparation/package_preparation_test.dart
+++ b/test/integration_tests/cli/preparation/package_preparation_test.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:dart_apitool/api_tool_cli.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+/// Tests for testing the package preparation
+/// Especially that the new approach of using a temporary package as an intermediary
+void main() {
+  group('Package Preparation', () {
+    late CommandRunner<int> runner;
+
+    setUp(() {
+      final extractCommand = ExtractCommand();
+      runner = CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+        ..addCommand(extractCommand);
+    });
+
+    Future<Map<String, dynamic>> getExtractResultJson(
+        String packageName, String version) async {
+      final tempDir = Directory.systemTemp.createTempSync();
+      final jsonReportFile = File(p.join(tempDir.path, 'report.json'));
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        'pub://$packageName/$version',
+        '--output',
+        jsonReportFile.path,
+      ]);
+      expect(exitCode, 0);
+      final result = jsonDecode(await jsonReportFile.readAsString());
+      await tempDir.delete(recursive: true);
+      return result;
+    }
+
+    test('Analyzes sentry 5.1.0 correctly', () async {
+      final result = await getExtractResultJson('sentry', '5.1.0');
+      final interfaceDeclarations =
+          result['packageApi']['interfaceDeclarations'] as List;
+      final sentryAssetBundleDeclaration =
+          interfaceDeclarations.singleWhere((id) => id['name'] == 'Scope');
+      final clearMethod =
+          (sentryAssetBundleDeclaration['executableDeclarations'] as List)
+              .singleWhere((ex) => ex['name'] == 'clear');
+      expect(clearMethod['returnTypeName'], 'void');
+    });
+
+    test('Analyzes cloud_firestore 4.3.1 correctly', () async {
+      final result = await getExtractResultJson('cloud_firestore', '4.3.1');
+      final interfaceDeclarations =
+          result['packageApi']['interfaceDeclarations'] as List;
+      final collectionReferenceDeclaration = interfaceDeclarations
+          .singleWhere((id) => id['name'] == 'CollectionReference');
+      final addMethod =
+          (collectionReferenceDeclaration['executableDeclarations'] as List)
+              .singleWhere((ex) => ex['name'] == 'add');
+      expect(addMethod['returnTypeName'], 'Future<DocumentReference<T>>');
+    });
+
+    test('Analyzes device_info_plus_platform_interface 2.2.0 correctly',
+        () async {
+      final result = await getExtractResultJson(
+          'device_info_plus_platform_interface', '2.2.0');
+      final interfaceDeclarations =
+          result['packageApi']['interfaceDeclarations'] as List;
+      final deviceInfoPlatformDeclaration = interfaceDeclarations
+          .singleWhere((id) => id['name'] == 'DeviceInfoPlatform');
+      final androidInfoMethod =
+          (deviceInfoPlatformDeclaration['executableDeclarations'] as List)
+              .singleWhere((ex) => ex['name'] == 'androidInfo');
+      expect(androidInfoMethod['returnTypeName'], 'Future<AndroidDeviceInfo>');
+    });
+
+    test('Analyzes http2 2.3.0 correctly', () async {
+      final result = await getExtractResultJson('http2', '2.3.0');
+      final interfaceDeclarations =
+          result['packageApi']['interfaceDeclarations'] as List;
+      final clientSettingsDeclaration = interfaceDeclarations
+          .singleWhere((id) => id['name'] == 'ClientSettings');
+      final allowServerPushesField =
+          (clientSettingsDeclaration['fieldDeclarations'] as List)
+              .singleWhere((fd) => fd['name'] == 'allowServerPushes');
+      expect(allowServerPushesField['typeName'], 'bool');
+    });
+
+    test('Analyzes sqflite_common 2.3.0 correctly', () async {
+      final result = await getExtractResultJson('sqflite_common', '2.3.0');
+      final interfaceDeclarations =
+          result['packageApi']['interfaceDeclarations'] as List;
+      final databaseFactoryDeclaration = interfaceDeclarations
+          .singleWhere((id) => id['name'] == 'DatabaseFactory');
+      final openDatabaseMethod =
+          (databaseFactoryDeclaration['executableDeclarations'] as List)
+              .singleWhere((ex) => ex['name'] == 'openDatabase');
+      expect(openDatabaseMethod['returnTypeName'], 'Future<Database>');
+    });
+  });
+}

--- a/test/integration_tests/diff/enum_ctor_and_tostring_test.dart
+++ b/test/integration_tests/diff/enum_ctor_and_tostring_test.dart
@@ -7,22 +7,30 @@ void main() {
     late PackageApiAnalyzer packageAWithEnumCtorAndToString;
     late PackageApiAnalyzer packageAWithoutEnumCtorAndToString;
 
+    final packageAPath = path.join(
+      'test',
+      'test_packages',
+      'enum_and_tostring',
+      'package_a_with_enum_ctor_and_tostring',
+    );
+
+    final packageBPath = path.join(
+      'test',
+      'test_packages',
+      'enum_and_tostring',
+      'package_a_without_enum_ctor_and_tostring',
+    );
+
     setUpAll(
       () {
         packageAWithEnumCtorAndToString = PackageApiAnalyzer(
-            packagePath: path.join(
-          'test',
-          'test_packages',
-          'enum_and_tostring',
-          'package_a_with_enum_ctor_and_tostring',
-        ));
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
         packageAWithoutEnumCtorAndToString = PackageApiAnalyzer(
-            packagePath: path.join(
-          'test',
-          'test_packages',
-          'enum_and_tostring',
-          'package_a_without_enum_ctor_and_tostring',
-        ));
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
 

--- a/test/integration_tests/diff/test_package_dynamic_handling_test.dart
+++ b/test/integration_tests/diff/test_package_dynamic_handling_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithDynamic = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'dynamic_handling',
           'package_a_with_dynamic_types',
-        ));
-        packageAWithStricterTypes = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'dynamic_handling',
           'package_a_with_stricter_types',
-        ));
+        );
+        packageAWithDynamic = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithStricterTypes = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('turning dynamic to Object?', () {

--- a/test/integration_tests/diff/test_package_experimental_test.dart
+++ b/test/integration_tests/diff/test_package_experimental_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithExperimental = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'experimental_and_sealed_diff',
           'package_a_with_experimental_and_sealed',
-        ));
-        packageAWithoutExperimental = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'experimental_and_sealed_diff',
           'package_a_without_experimental_and_sealed',
-        ));
+        );
+        packageAWithExperimental = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithoutExperimental = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('with experimental to without experimental', () {

--- a/test/integration_tests/diff/test_package_field_to_property_test.dart
+++ b/test/integration_tests/diff/test_package_field_to_property_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithField = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'field_to_property',
           'package_a_with_field',
-        ));
-        packageAWithProperty = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'field_to_property',
           'package_a_with_property',
-        ));
+        );
+        packageAWithField = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithProperty = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('changing a field to a read-only property', () {

--- a/test/integration_tests/diff/test_package_library_rename_test.dart
+++ b/test/integration_tests/diff/test_package_library_rename_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithOldLibraryName = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'library_rename_without_entry_point_change',
           'package_a_with_old_library_name',
-        ));
-        packageAWithNewLibraryName = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'library_rename_without_entry_point_change',
           'package_a_with_new_library_name',
-        ));
+        );
+        packageAWithOldLibraryName = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithNewLibraryName = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('diff', () {

--- a/test/integration_tests/diff/test_package_operators_test.dart
+++ b/test/integration_tests/diff/test_package_operators_test.dart
@@ -9,22 +9,28 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithRecord = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'operators',
           'package_a_with_operators',
-        ));
+        );
+        final packageBPath = path.join(
+          'test',
+          'test_packages',
+          'operators',
+          'package_a_with_operators',
+        );
+        packageAWithRecord = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
         // we test the same package against itself.
         // We just want to know if the differ can handle two operators with the same name
         packageAWithChangedRecord = PackageApiAnalyzer(
-            packagePath: path.join(
-          'test',
-          'test_packages',
-          'operators',
-          'package_a_with_operators',
-        ));
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('having the - operator two times (unary and not)', () {

--- a/test/integration_tests/diff/test_package_records_test.dart
+++ b/test/integration_tests/diff/test_package_records_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithRecord = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'records',
           'package_a_with_record',
-        ));
-        packageAWithChangedRecord = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'records',
           'package_a_with_changed_record',
-        ));
+        );
+        packageAWithRecord = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithChangedRecord = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('changing the record type structure', () {

--- a/test/integration_tests/diff/test_package_sealed_test.dart
+++ b/test/integration_tests/diff/test_package_sealed_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithExperimental = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'experimental_and_sealed_diff',
           'package_a_with_experimental_and_sealed',
-        ));
-        packageAWithoutExperimental = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'experimental_and_sealed_diff',
           'package_a_without_experimental_and_sealed',
-        ));
+        );
+        packageAWithExperimental = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithoutExperimental = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('with sealed to without sealed', () {

--- a/test/integration_tests/diff/test_package_static_test.dart
+++ b/test/integration_tests/diff/test_package_static_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithoutStaticElement = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'static_elements',
           'package_a_without_static_element',
-        ));
-        packageAWithStaticElement = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'static_elements',
           'package_a_with_static_element',
-        ));
+        );
+        packageAWithoutStaticElement = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithStaticElement = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('adding a static method to a required type', () {

--- a/test/integration_tests/diff/test_package_widening_types_test.dart
+++ b/test/integration_tests/diff/test_package_widening_types_test.dart
@@ -9,20 +9,26 @@ void main() {
 
     setUpAll(
       () {
-        packageAWithNarrowTypes = PackageApiAnalyzer(
-            packagePath: path.join(
+        final packageAPath = path.join(
           'test',
           'test_packages',
           'widening_types_diff',
           'package_a_with_narrow_types',
-        ));
-        packageAWithWiderTypes = PackageApiAnalyzer(
-            packagePath: path.join(
+        );
+        final packageBPath = path.join(
           'test',
           'test_packages',
           'widening_types_diff',
           'package_a_with_wider_types',
-        ));
+        );
+        packageAWithNarrowTypes = PackageApiAnalyzer(
+          packagePath: packageAPath,
+          analyzerRootPath: packageAPath,
+        );
+        packageAWithWiderTypes = PackageApiAnalyzer(
+          packagePath: packageBPath,
+          analyzerRootPath: packageBPath,
+        );
       },
     );
     group('widening types', () {

--- a/test/integration_tests/helper/integration_test_helper.dart
+++ b/test/integration_tests/helper/integration_test_helper.dart
@@ -22,6 +22,7 @@ class PackageApiRetriever {
     );
     final analyzer = PackageApiAnalyzer(
       packagePath: packageDirectory,
+      analyzerRootPath: packageDirectory,
       doConsiderNonSrcAsEntryPoints: doConsiderNonSrcAsEntryPoints,
     );
     print('Analyzing $packageName $packageVersion');
@@ -57,6 +58,7 @@ class GitPackageApiRetriever {
 
     final analyzer = PackageApiAnalyzer(
       packagePath: tempDir.path,
+      analyzerRootPath: tempDir.path,
       doConsiderNonSrcAsEntryPoints: doConsiderNonSrcAsEntryPoints,
     );
     print('Analyzing $gitUrl $gitRef');


### PR DESCRIPTION
## Description
The former approach to analyze packages (especially the ones from pub) was to copy the package content + adapt it to make `pub get` run through.

This approach has limitations and runs into all kind of issues as packages in the pub cache are not meant to be executed `pub get` directly in and certain conditions lead to failing `pub get` runs:
- example project that refers to non-existing packages from the original monorepo
- the package's dev dependencies are pointing to non-existing packages
- the package is part of a workspace

To bypass this approach completely Google employers had the idea of generating a temporary package that references the package to analyze and use that temporary package as an `pub get` and analysis entry-point.

This change is considered breaking as the output might change

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
