### PR TITLE
Fix: run pub get indirectly

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.29.3",
+  "flutter": "3.32.1",
   "flavors": {}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.29.3",
+  "dart.flutterSdkPath": ".fvm/versions/3.32.1",
   "dart.sdkPath": ".fvm/flutter_sdk/bin/cache/dart-sdk",
   "search.exclude": {
     "**/.fvm": true

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage: dart-apitool extract [arguments]
     --output                             Output file for the extracted Package API.
                                          If not specified the extracted API will be printed to the console.
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
-    --[no-]remove-example                Removes examples from the package to analyze.
+    --[no-]remove-example                DEPRECATED - Removes examples from the package to analyze. (has no effect any more)
                                          (defaults to on)
     --[no-]set-exit-on-missing-export    Sets exit code to != 0 if missing exports are detected in the API.
     --force-use-flutter                  If present forces dart_apitool to use Flutter
@@ -80,7 +80,7 @@ Usage: dart-apitool diff [arguments]
                                          - any package from pub
                                            (e.g. pub://package_name/version)
 -p, --[no-]include-path-dependencies     OBSOLETE: Has no effect anymore.
-    --version-check-mode                 Defines the mode the versions of the packages shall be compared.
+    --version-check-mode                 Defines the mode the versions of the packages shall be compared. 
                                          This affects the exit code of this program.
                                          [none, fully (default), onlyBreakingChanges]
     --[no-]check-sdk-version             Determines if the SDK version should be checked.
@@ -93,9 +93,9 @@ Usage: dart-apitool diff [arguments]
     --no-analyze-platform-constraints    Disables analysis of platform constraints.
     --dependency-check-mode              DEPRECATED - this option as no effect any more
                                          [none, allowAdding (default), strict]
-    --[no-]remove-example                Removes examples from the package to analyze.
+    --[no-]remove-example                DEPRECATED - Removes examples from the package to analyze. (has no effect any more)
                                          (defaults to on)
-    --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces
+    --[no-]ignore-requiredness           Whether to ignore the required aspect of interfaces 
                                          (yielding less strict version bump requirements)
     --report-format                      Which output format should be used
                                          [cli (default), markdown, json]

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -4,7 +4,6 @@ import 'package:args/args.dart';
 import 'package:dart_apitool/api_tool.dart';
 import 'package:dart_apitool/src/cli/source_item.dart';
 import 'package:path/path.dart' as p;
-import 'package:pubspec_manager/pubspec_manager.dart';
 
 import '../package_ref.dart';
 import '../prepared_package_ref.dart';
@@ -137,7 +136,6 @@ OBSOLETE: Has no effect anymore.
     ArgResults argResults,
     PreparedPackageRef preparedRef, {
     bool doAnalyzePlatformConstraints = true,
-    bool doRemoveExample = true,
   }) async {
     final stdoutSession = StdoutSession();
 
@@ -164,10 +162,6 @@ OBSOLETE: Has no effect anymore.
         File(p.join(packagePath, 'analysis_options.yaml'));
     if (await analysisOptionsFile.exists()) {
       await analysisOptionsFile.delete();
-    }
-    final exampleDirPath = p.join(packagePath, 'example');
-    if (doRemoveExample && await Directory(exampleDirPath).exists()) {
-      await Directory(exampleDirPath).delete(recursive: true);
     }
 
     // Check if the package_config.json is already present from the preparation step

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -108,21 +107,10 @@ OBSOLETE: Has no effect anymore.
           stdoutSession: stdoutSession,
           forceUseFlutterTool: forceUseFlutterTool,
         );
-        final sourcePackageConfig = File(_getPackageConfigPathForPackage(
-          sourceItem.sourceDir,
+        await DartInteraction.transferPackageConfig(
+          fromPackage: sourceItem.sourceDir,
+          toPackage: tempDir.path,
           stdoutSession: stdoutSession,
-          doCheckWorkspace: true,
-        ));
-        final targetPackageConfig = File(_getPackageConfigPathForPackage(
-          tempDir.path,
-          stdoutSession: stdoutSession,
-          doCheckWorkspace: false,
-        ))
-          ..createSync(recursive: true);
-        await sourcePackageConfig.copy(targetPackageConfig.path);
-        await _adaptPackageConfigToAbsolutePaths(
-          targetPackageConfigPath: targetPackageConfig.absolute.path,
-          sourcePackageConfigPath: sourcePackageConfig.absolute.path,
         );
       } else {
         await stdoutSession.writeln('Cleaning up local copy of pub package');
@@ -182,38 +170,15 @@ OBSOLETE: Has no effect anymore.
       await Directory(exampleDirPath).delete(recursive: true);
     }
 
-    // remove any dependency overrides and workspace resolutions from the pubspec.yaml
-    final pubspecFile = File(p.join(packagePath, 'pubspec.yaml'));
-    if (pubspecFile.existsSync()) {
-      try {
-        final pubSpec = PubSpec.load(directory: packagePath);
-        // removeAll of dependencyOverrides has an issue in the current version of pubspec_manager
-        // as it doesn't remove the section part of the dependency overrides and therefore are not removed
-        // in the saved version of the pubspec.yaml file
-        // workaround: remove all dependency overrides manually
-        for (final depOverride in pubSpec.dependencyOverrides.list) {
-          pubSpec.dependencyOverrides.remove(depOverride.name);
-        }
-        if (!pubSpec.document.findSectionForKey('resolution').missing) {
-          pubSpec.document.removeAll(
-              pubSpec.document.findSectionForKey('resolution').lines);
-        }
-        pubSpec.save();
-      } catch (e) {
-        await stdoutSession.writeln(
-            'Error removing dependency overrides from pubspec.yaml: $e');
-      }
-    }
-
     // Check if the package_config.json is already present from the preparation step
-    final packageConfig = File(_getPackageConfigPathForPackage(
+    final packageConfig = File(DartInteraction.getPackageConfigPathForPackage(
       packagePath,
       stdoutSession: stdoutSession,
       doCheckWorkspace: true,
     ));
     if (!packageConfig.existsSync()) {
       await stdoutSession.writeln('Running pub get');
-      await PubInteraction.runPubGet(
+      await PubInteraction.runPubGetIndirectly(
         packagePath,
         stdoutSession: stdoutSession,
         forceUseFlutterTool: forceUseFlutterTool,
@@ -271,95 +236,4 @@ OBSOLETE: Has no effect anymore.
       }
     }
   }
-
-  Future _adaptPackageConfigToAbsolutePaths({
-    required String targetPackageConfigPath,
-    required String sourcePackageConfigPath,
-  }) async {
-    final sourcePackageConfigDirPath = p.dirname(sourcePackageConfigPath);
-    final sourcePackageDirPath =
-        Directory(sourcePackageConfigDirPath).parent.path;
-    final targetPackageConfigContent =
-        jsonDecode(await File(targetPackageConfigPath).readAsString());
-    // iterate through the package_config.json content and look for relative paths
-    for (final packageConfig in targetPackageConfigContent['packages']) {
-      final rootUri = Uri.parse(packageConfig['rootUri']);
-      final packagePath = p.fromUri(rootUri);
-      if (p.isRelative(packagePath)) {
-        // we make the relative path absolute by using the origin of the source package config as a base
-        final normalizedPackagePath =
-            p.normalize(p.join(sourcePackageConfigDirPath, packagePath));
-        // if the relative path is the package path, then don't make it absolute
-        if (p.equals(sourcePackageDirPath, normalizedPackagePath)) {
-          continue;
-        }
-        // and write the new absolute path back to the json structure
-        packageConfig['rootUri'] = p.toUri(normalizedPackagePath).toString();
-      }
-    }
-    final encoder = JsonEncoder.withIndent('    ');
-    // replace the package config with the new content
-    await File(targetPackageConfigPath).writeAsString(
-      encoder.convert(targetPackageConfigContent),
-      mode: FileMode.write,
-    );
-  }
-
-  String _getPackageConfigPathForPackage(
-    String packagePath, {
-    required StdoutSession stdoutSession,
-    required bool doCheckWorkspace,
-  }) {
-    String packageConfigPackagePath = packagePath;
-    final packageDir = Directory(packagePath);
-    if (doCheckWorkspace && packageDir.existsSync()) {
-      // if the package directory exists (source) then we check if we have to deal with a workspace
-      try {
-        final pubspec = PubSpec.load(directory: packagePath);
-        final resolutionSection =
-            pubspec.document.findSectionForKey('resolution');
-        if (!resolutionSection.missing) {
-          bool resolvesWithWorkspace = false;
-          for (final line in resolutionSection.lines) {
-            if (line.text.contains('resolution:') &&
-                line.text.trim().endsWith('workspace')) {
-              resolvesWithWorkspace = true;
-              break;
-            }
-          }
-          if (resolvesWithWorkspace) {
-            final workspacePath = _findWorkspacePath(packagePath);
-            if (workspacePath == null) {
-              stdoutSession
-                  .writeln('Could not find workspace for package $packagePath');
-            } else {
-              packageConfigPackagePath = workspacePath;
-            }
-          }
-        }
-      } catch (e) {
-        stdoutSession
-            .writeln('Error loading pubspec.yaml, continuing anyways: $e');
-      }
-    }
-    return p.join(
-        packageConfigPackagePath, '.dart_tool', 'package_config.json');
-  }
-}
-
-String? _findWorkspacePath(String packagePath) {
-  Directory currentDirectory = Directory(packagePath).parent;
-  while (currentDirectory.path != currentDirectory.parent.path) {
-    if (!File(p.join(currentDirectory.path, 'pubspec.yaml')).existsSync()) {
-      currentDirectory = currentDirectory.parent;
-      continue;
-    }
-    final pubspec = PubSpec.load(directory: currentDirectory.path);
-    if (pubspec.document.findSectionForKey('workspace').missing) {
-      currentDirectory = currentDirectory.parent;
-    } else {
-      return currentDirectory.path;
-    }
-  }
-  return null;
 }

--- a/lib/src/cli/commands/diff_command.dart
+++ b/lib/src/cli/commands/diff_command.dart
@@ -92,7 +92,8 @@ You may want to do this if you want to make sure
     );
     argParser.addFlag(
       _optionNameRemoveExample,
-      help: 'Removes examples from the package to analyze.',
+      help:
+          'DEPRECATED - Removes examples from the package to analyze. (has no effect any more)',
       defaultsTo: true,
       negatable: true,
     );
@@ -149,7 +150,6 @@ Whether to ignore the required aspect of interfaces
       stdout.writeln(
           'You are using the option "$_optionNameDependencyCheckMode" that has no effect any more and will be removed in a future release (and will lead to an exception if specified)');
     }
-    final doRemoveExample = argResults![_optionNameRemoveExample] as bool;
     final doIgnoreRequiredness =
         argResults![_optionNameIgnoreRequiredness] as bool;
 
@@ -166,13 +166,11 @@ Whether to ignore the required aspect of interfaces
       argResults!,
       preparedOldPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
-      doRemoveExample: doRemoveExample,
     );
     final newPackageApi = await analyze(
       argResults!,
       preparedNewPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
-      doRemoveExample: doRemoveExample,
     );
 
     await cleanUp(preparedOldPackageRef);

--- a/lib/src/cli/commands/extract_command.dart
+++ b/lib/src/cli/commands/extract_command.dart
@@ -50,7 +50,8 @@ If not specified the extracted API will be printed to the console.
     );
     argParser.addFlag(
       _optionNameRemoveExample,
-      help: 'Removes examples from the package to analyze.',
+      help:
+          'DEPRECATED - Removes examples from the package to analyze. (has no effect any more)',
       defaultsTo: true,
       negatable: true,
     );
@@ -69,7 +70,6 @@ If not specified the extracted API will be printed to the console.
     final packageRef = PackageRef(argResults![_optionNameInput]);
     final noAnalyzePlatformConstraints =
         argResults![_optionNameNoAnalyzePlatformConstraints] as bool;
-    final doRemoveExample = argResults![_optionNameRemoveExample] as bool;
     final doSetExitCodeOnMissingExport =
         argResults![_optionNameSetExitCodeOnMissingExport] as bool;
 
@@ -81,7 +81,6 @@ If not specified the extracted API will be printed to the console.
       argResults!,
       preparedPackageRef,
       doAnalyzePlatformConstraints: !noAnalyzePlatformConstraints,
-      doRemoveExample: doRemoveExample,
     );
     await cleanUp(preparedPackageRef);
 

--- a/lib/src/tooling/pub_interaction.dart
+++ b/lib/src/tooling/pub_interaction.dart
@@ -187,6 +187,15 @@ abstract class PubInteraction {
     final forDirectoryPubspec =
         Pubspec.parse(File(forDirectoryPubspecPath).readAsStringSync());
     final packageName = forDirectoryPubspec.name;
+    final isFlutter = forDirectoryPubspec.flutter != null;
+
+    String potentialFlutterBloc = isFlutter
+        ? '''
+  flutter:
+    sdk: flutter
+'''
+        : '';
+
     final tempDirectory = Directory.systemTemp.createTempSync();
     final tempPackagePath = path.join(tempDirectory.path, 'temp_package');
     final tempPackagePubspecPath = path.join(tempPackagePath, 'pubspec.yaml');
@@ -203,6 +212,7 @@ environment:
 dependencies:
   $packageName:
     path: $forDirectory
+$potentialFlutterBloc
 ''',
     );
     await DartInteraction.runDartOrFlutterCommand(tempPackagePath,

--- a/lib/src/tooling/pub_interaction.dart
+++ b/lib/src/tooling/pub_interaction.dart
@@ -4,6 +4,7 @@ import 'package:dart_apitool/src/tooling/dart_interaction.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
 import '../errors/run_dart_error.dart';
 import '../utils/utils.dart';
 
@@ -174,5 +175,45 @@ abstract class PubInteraction {
       stdoutSession: stdoutSession,
       forceUseFlutterTool: forceUseFlutterTool,
     );
+  }
+
+  /// runs pub get indirectly by creating a temporary package that refers to [forDirectory] and copying the result back
+  static Future runPubGetIndirectly(
+    String forDirectory, {
+    required StdoutSession stdoutSession,
+    bool forceUseFlutterTool = false,
+  }) async {
+    final forDirectoryPubspecPath = path.join(forDirectory, 'pubspec.yaml');
+    final forDirectoryPubspec =
+        Pubspec.parse(File(forDirectoryPubspecPath).readAsStringSync());
+    final packageName = forDirectoryPubspec.name;
+    final tempDirectory = Directory.systemTemp.createTempSync();
+    final tempPackagePath = path.join(tempDirectory.path, 'temp_package');
+    final tempPackagePubspecPath = path.join(tempPackagePath, 'pubspec.yaml');
+    Directory(tempPackagePath).createSync(recursive: true);
+    File(tempPackagePubspecPath).writeAsStringSync(
+      '''
+name: temp_package
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  $packageName:
+    path: $forDirectory
+''',
+    );
+    await DartInteraction.runDartOrFlutterCommand(tempPackagePath,
+        args: ['pub', 'get'],
+        stdoutSession: stdoutSession,
+        forceUseFlutterTool: forceUseFlutterTool);
+    await DartInteraction.transferPackageConfig(
+      fromPackage: tempPackagePath,
+      toPackage: forDirectory,
+      stdoutSession: stdoutSession,
+    );
+    await Directory(tempDirectory.path).delete(recursive: true);
   }
 }

--- a/lib/src/tooling/pub_interaction.dart
+++ b/lib/src/tooling/pub_interaction.dart
@@ -189,7 +189,7 @@ abstract class PubInteraction {
     final packageName = forDirectoryPubspec.name;
     final isFlutter = forDirectoryPubspec.flutter != null;
 
-    String potentialFlutterBloc = isFlutter
+    String potentialFlutterDependency = isFlutter
         ? '''
   flutter:
     sdk: flutter
@@ -212,7 +212,7 @@ environment:
 dependencies:
   $packageName:
     path: $forDirectory
-$potentialFlutterBloc
+$potentialFlutterDependency
 ''',
     );
     await DartInteraction.runDartOrFlutterCommand(tempPackagePath,

--- a/test/integration_tests/cli/preparation/package_preparation_test.dart
+++ b/test/integration_tests/cli/preparation/package_preparation_test.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:dart_apitool/api_tool_cli.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+import '../../helper/integration_test_helper.dart';
+
+/// Tests for testing the package preparation
+/// Especially that the new approach of using a temporary package as an intermediary
+void main() {
+  group('Package Preparation', () {
+    late CommandRunner<int> runner;
+
+    setUp(() {
+      final extractCommand = ExtractCommand();
+      runner = CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+        ..addCommand(extractCommand);
+    });
+
+    Future<Map<String, dynamic>> getExtractResultJson(
+        String packageName, String version) async {
+      final tempDir = Directory.systemTemp.createTempSync();
+      final jsonReportFile = File(p.join(tempDir.path, 'report.json'));
+      final exitCode = await runner.run([
+        'extract',
+        '--input',
+        'pub://$packageName/$version',
+        '--output',
+        jsonReportFile.path,
+      ]);
+      expect(exitCode, 0);
+      final result = jsonDecode(await jsonReportFile.readAsString());
+      await tempDir.delete(recursive: true);
+      return result;
+    }
+
+    test(
+      'Analyzes sentry 5.1.0 correctly',
+      () async {
+        final result = await getExtractResultJson('sentry', '5.1.0');
+        final interfaceDeclarations =
+            result['packageApi']['interfaceDeclarations'] as List;
+        final sentryAssetBundleDeclaration =
+            interfaceDeclarations.singleWhere((id) => id['name'] == 'Scope');
+        final clearMethod =
+            (sentryAssetBundleDeclaration['executableDeclarations'] as List)
+                .singleWhere((ex) => ex['name'] == 'clear');
+        expect(clearMethod['returnTypeName'], 'void');
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
+      'Analyzes cloud_firestore 4.3.1 correctly',
+      () async {
+        final result = await getExtractResultJson('cloud_firestore', '4.3.1');
+        final interfaceDeclarations =
+            result['packageApi']['interfaceDeclarations'] as List;
+        final collectionReferenceDeclaration = interfaceDeclarations
+            .singleWhere((id) => id['name'] == 'CollectionReference');
+        final addMethod =
+            (collectionReferenceDeclaration['executableDeclarations'] as List)
+                .singleWhere((ex) => ex['name'] == 'add');
+        expect(addMethod['returnTypeName'], 'Future<DocumentReference<T>>');
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
+      'Analyzes device_info_plus_platform_interface 2.2.0 correctly',
+      () async {
+        final result = await getExtractResultJson(
+            'device_info_plus_platform_interface', '2.2.0');
+        final interfaceDeclarations =
+            result['packageApi']['interfaceDeclarations'] as List;
+        final deviceInfoPlatformDeclaration = interfaceDeclarations
+            .singleWhere((id) => id['name'] == 'DeviceInfoPlatform');
+        final androidInfoMethod =
+            (deviceInfoPlatformDeclaration['executableDeclarations'] as List)
+                .singleWhere((ex) => ex['name'] == 'androidInfo');
+        expect(
+            androidInfoMethod['returnTypeName'], 'Future<AndroidDeviceInfo>');
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
+      'Analyzes http2 2.3.0 correctly',
+      () async {
+        final result = await getExtractResultJson('http2', '2.3.0');
+        final interfaceDeclarations =
+            result['packageApi']['interfaceDeclarations'] as List;
+        final clientSettingsDeclaration = interfaceDeclarations
+            .singleWhere((id) => id['name'] == 'ClientSettings');
+        final allowServerPushesField =
+            (clientSettingsDeclaration['fieldDeclarations'] as List)
+                .singleWhere((fd) => fd['name'] == 'allowServerPushes');
+        expect(allowServerPushesField['typeName'], 'bool');
+      },
+      timeout: integrationTestTimeout,
+    );
+
+    test(
+      'Analyzes sqflite_common 2.3.0 correctly',
+      () async {
+        final result = await getExtractResultJson('sqflite_common', '2.3.0');
+        final interfaceDeclarations =
+            result['packageApi']['interfaceDeclarations'] as List;
+        final databaseFactoryDeclaration = interfaceDeclarations
+            .singleWhere((id) => id['name'] == 'DatabaseFactory');
+        final openDatabaseMethod =
+            (databaseFactoryDeclaration['executableDeclarations'] as List)
+                .singleWhere((ex) => ex['name'] == 'openDatabase');
+        expect(openDatabaseMethod['returnTypeName'], 'Future<Database>');
+      },
+      timeout: integrationTestTimeout,
+    );
+  });
+}


### PR DESCRIPTION
## Description
The former approach to analyze packages (especially the ones from pub) was to copy the package content + adapt it to make `pub get` run through.

This approach has limitations and runs into all kind of issues as packages in the pub cache are not meant to be executed `pub get` directly in and certain conditions lead to failing `pub get` runs:
- example project that refers to non-existing packages from the original monorepo
- the package's dev dependencies are pointing to non-existing packages
- the package is part of a workspace

To bypass this approach completely Google employees had the idea of generating a temporary package that references the package to analyze and use that temporary package as an `pub get` and analysis entry-point.

This approach can't be used as a complete replacement of the copying as we need to do other adaptions like removing the analysis options.

But instead of running `pub get` inside the package copy (and adapting all the things to make it pass) we now call `pub get` indirectly using a temporary package.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping

fixes #212 