### PR TITLE
fix: narrowing return type should not be breaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ coverage
 
 # asdf config
 /.tool-versions
+
+# Kiro
+.kiro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.21.2
 - fix: Fixes an issue if we have to deal with two types with the same name
 - feat: add support for @internal annotations
+- fix: Narrowing return types (generics) should not be considered a breaking change
 
 ## Version 0.21.1
 - fix: Fix analysis of pub cache packages

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -396,7 +396,6 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
       namespace: _context.namespace,
       rootPath: _context.rootPath,
     ));
-    // if the function is internal then we don't collect its return type as used
     if (element.returnType.element3 != null) {
       _onTypeUsed(element.returnType, element,
           typeUsageKind: TypeUsageKind.output);

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -396,6 +396,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
       namespace: _context.namespace,
       rootPath: _context.rootPath,
     ));
+    // if the function is internal then we don't collect its return type as used
     if (element.returnType.element3 != null) {
       _onTypeUsed(element.returnType, element,
           typeUsageKind: TypeUsageKind.output);

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -283,7 +283,7 @@ class TypeHierarchy {
   }
 
   /// Extracts the base type name from a potentially generic type
-  /// e.g., "List<int>" -> "List", "String" -> "String"
+  /// e.g., "`List<int>`" -> "List", "String" -> "String"
   String _extractBaseTypeName(String typeName) {
     final genericStart = typeName.indexOf('<');
     if (genericStart == -1) {
@@ -292,7 +292,7 @@ class TypeHierarchy {
     return typeName.substring(0, genericStart);
   }
 
-  /// Checks if generic types are covariant (e.g., List<int> is subtype of List<num>)
+  /// Checks if generic types are covariant (e.g., `List<int>` is subtype of `List<num>`)
   bool _isGenericTypeCovariant(String subType, String superType) {
     final subTypeInfo = _parseGenericType(subType);
     final superTypeInfo = _parseGenericType(superType);

--- a/lib/src/model/type_hierarchy.dart
+++ b/lib/src/model/type_hierarchy.dart
@@ -154,6 +154,26 @@ sealed class TypeIdentifier with _$TypeIdentifier {
 class TypeHierarchy {
   final Map<String, Set<_TypeHierarchyItem>> _types = {};
 
+  /// Built-in Dart type hierarchy relationships
+  /// Maps type names to their supertypes
+  static const Map<String, Set<String>> _builtInTypeHierarchy = {
+    'int': {'num', 'Object'},
+    'double': {'num', 'Object'},
+    'num': {'Object'},
+    'String': {'Object'},
+    'bool': {'Object'},
+    'List': {'Iterable', 'Object'},
+    'Set': {'Iterable', 'Object'},
+    'Map': {'Object'},
+    'Iterable': {'Object'},
+    'Future': {'Object'},
+    'Stream': {'Object'},
+    'Symbol': {'Object'},
+    'Type': {'Object'},
+    'Function': {'Object'},
+    'Record': {'Object'},
+  };
+
   TypeHierarchy._();
 
   /// creates an empty type hierarchy
@@ -232,10 +252,140 @@ class TypeHierarchy {
     return isTypePassedIn ? oldIsSubtypeOfNew : newIsSubtypeOfOld;
   }
 
+  /// Checks if [potentialSubType] is a built-in subtype of [superType]
+  bool _isBuiltInSubType(
+    TypeIdentifier potentialSubType,
+    TypeIdentifier superType,
+  ) {
+    // Extract base type names (without generic parameters)
+    final subTypeName =
+        _extractBaseTypeName(potentialSubType.nonNullableTypeName);
+    final superTypeName = _extractBaseTypeName(superType.nonNullableTypeName);
+
+    // Check if both types are from the same package (built-in types should have empty package names)
+    if (potentialSubType.packageName != superType.packageName) {
+      return false;
+    }
+
+    // Check direct built-in type relationships
+    final superTypes = _builtInTypeHierarchy[subTypeName];
+    if (superTypes != null && superTypes.contains(superTypeName)) {
+      return true;
+    }
+
+    // Check generic type covariance for common collection types
+    if (_isGenericTypeCovariant(
+        potentialSubType.nonNullableTypeName, superType.nonNullableTypeName)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Extracts the base type name from a potentially generic type
+  /// e.g., "List<int>" -> "List", "String" -> "String"
+  String _extractBaseTypeName(String typeName) {
+    final genericStart = typeName.indexOf('<');
+    if (genericStart == -1) {
+      return typeName;
+    }
+    return typeName.substring(0, genericStart);
+  }
+
+  /// Checks if generic types are covariant (e.g., List<int> is subtype of List<num>)
+  bool _isGenericTypeCovariant(String subType, String superType) {
+    final subTypeInfo = _parseGenericType(subType);
+    final superTypeInfo = _parseGenericType(superType);
+
+    // Both must be generic types with the same base type
+    if (subTypeInfo == null || superTypeInfo == null) {
+      return false;
+    }
+
+    if (subTypeInfo.baseType != superTypeInfo.baseType) {
+      return false;
+    }
+
+    // Check if the base type supports covariance
+    if (!_isCovariantGenericType(subTypeInfo.baseType)) {
+      return false;
+    }
+
+    // For covariant types, check if all type arguments are subtypes
+    if (subTypeInfo.typeArguments.length !=
+        superTypeInfo.typeArguments.length) {
+      return false;
+    }
+
+    for (int i = 0; i < subTypeInfo.typeArguments.length; i++) {
+      final subArg = subTypeInfo.typeArguments[i];
+      final superArg = superTypeInfo.typeArguments[i];
+
+      // Create type identifiers for the type arguments
+      final subArgType = TypeIdentifier(
+        typeName: subArg,
+        packageName: '',
+        packageRelativeLibraryPath: '',
+      );
+      final superArgType = TypeIdentifier(
+        typeName: superArg,
+        packageName: '',
+        packageRelativeLibraryPath: '',
+      );
+
+      // Check if subArg is a subtype of superArg
+      if (!_isBuiltInSubType(subArgType, superArgType) && subArg != superArg) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Checks if a generic type supports covariance
+  bool _isCovariantGenericType(String baseType) {
+    // These generic types are covariant in Dart
+    return const {'List', 'Set', 'Iterable', 'Future', 'Stream'}
+        .contains(baseType);
+  }
+
+  /// Parses a generic type into base type and type arguments
+  _GenericTypeInfo? _parseGenericType(String typeName) {
+    final genericStart = typeName.indexOf('<');
+    if (genericStart == -1) {
+      return null; // Not a generic type
+    }
+
+    final genericEnd = typeName.lastIndexOf('>');
+    if (genericEnd == -1 || genericEnd <= genericStart) {
+      return null; // Malformed generic type
+    }
+
+    final baseType = typeName.substring(0, genericStart);
+    final typeArgsString = typeName.substring(genericStart + 1, genericEnd);
+
+    // Simple parsing - split by comma (doesn't handle nested generics perfectly)
+    final typeArguments = typeArgsString
+        .split(',')
+        .map((arg) => arg.trim())
+        .where((arg) => arg.isNotEmpty)
+        .toList();
+
+    return _GenericTypeInfo(
+      baseType: baseType,
+      typeArguments: typeArguments,
+    );
+  }
+
   bool _isSubTypeOf(
     TypeIdentifier potentialSubTypeIdentifier,
     TypeIdentifier superTypeIdentifier,
   ) {
+    // First check built-in type relationships
+    if (_isBuiltInSubType(potentialSubTypeIdentifier, superTypeIdentifier)) {
+      return true;
+    }
+
     // if we can't find the type we try to use the nullable / non-nullable variant
     if (!_types.containsKey(potentialSubTypeIdentifier.packageAndTypeName)) {
       if (potentialSubTypeIdentifier.isNullable) {
@@ -278,6 +428,17 @@ class TypeHierarchy {
       return _isSubTypeOf(bti, superTypeIdentifier);
     });
   }
+}
+
+/// Helper class for parsing generic type information
+class _GenericTypeInfo {
+  final String baseType;
+  final List<String> typeArguments;
+
+  _GenericTypeInfo({
+    required this.baseType,
+    required this.typeArguments,
+  });
 }
 
 /// represents a type in the type hierarchy

--- a/test/integration_tests/diff/test_package_dynamic_handling_test.dart
+++ b/test/integration_tests/diff/test_package_dynamic_handling_test.dart
@@ -45,25 +45,25 @@ void main() {
         );
       });
 
-      test('is a breaking change for function return types', () {
+      test('is no breaking change for function return types', () {
         final functionChange = diffResult.apiChanges
             .where((ac) =>
                 ac.affectedDeclaration?.name.contains('function') ?? false)
             .single;
         expect(
           functionChange.isBreaking,
-          isTrue,
+          isFalse,
         );
       });
 
-      test('is a breaking change for property types)', () {
+      test('is no breaking change for property types)', () {
         final functionChange = diffResult.apiChanges
             .where((ac) =>
                 ac.affectedDeclaration?.name.contains('property') ?? false)
             .single;
         expect(
           functionChange.isBreaking,
-          isTrue,
+          isFalse,
         );
       });
     });
@@ -87,25 +87,25 @@ void main() {
         );
       });
 
-      test('is no breaking change for function return types', () {
+      test('is a breaking change for function return types', () {
         final functionChange = diffResult.apiChanges
             .where((ac) =>
                 ac.affectedDeclaration?.name.contains('function') ?? false)
             .single;
         expect(
           functionChange.isBreaking,
-          isFalse,
+          isTrue,
         );
       });
 
-      test('is no breaking change for property types)', () {
+      test('is a breaking change for property types)', () {
         final functionChange = diffResult.apiChanges
             .where((ac) =>
                 ac.affectedDeclaration?.name.contains('property') ?? false)
             .single;
         expect(
           functionChange.isBreaking,
-          isFalse,
+          isTrue,
         );
       });
     });

--- a/test/integration_tests/diff/test_package_return_type_changes_test.dart
+++ b/test/integration_tests/diff/test_package_return_type_changes_test.dart
@@ -142,6 +142,101 @@ void main() {
               'Narrowing Iterable<num> to List<int> should be non-breaking for return types (both base type and type parameter narrowing)',
         );
       });
+
+      test(
+          'detects Map<String, dynamic> to Map<String, String> as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('Map<String, dynamic> -> Map<String, String>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing Map<String, dynamic> to Map<String, String> should be non-breaking for return types',
+        );
+      });
+
+      test(
+          'detects Map<String, String?> to Map<String, String> as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('Map<String, String?> -> Map<String, String>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing Map<String, String?> to Map<String, String> should be non-breaking for return types',
+        );
+      });
+
+      test('detects List<String?> to List<String> as non-breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('List<String?> -> List<String>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing List<String?> to List<String> should be non-breaking for return types',
+        );
+      });
+
+      test('detects List<dynamic> to List<String> as non-breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('List<dynamic> -> List<String>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing List<dynamic> to List<String> should be non-breaking for return types',
+        );
+      });
+
+      test('detects dynamic to int return type change as non-breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('dynamic -> int') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing dynamic to int should be non-breaking for return types',
+        );
+      });
+
+      test(
+          'detects SomeSuperType? to SomeSuperType return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('SomeSuperType? -> SomeSuperType') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing SomeSuperType? to SomeSuperType should be non-breaking for return types',
+        );
+      });
     });
 
     group('return type widening (should be breaking)', () {
@@ -222,6 +317,98 @@ void main() {
           isTrue,
           reason:
               'Widening List<int> to Iterable<num> should be breaking for return types (both base type and type parameter widening)',
+        );
+      });
+
+      test('detects Map<String, String> to Map<String, dynamic> as breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('Map<String, String> -> Map<String, dynamic>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening Map<String, String> to Map<String, dynamic> should be breaking for return types',
+        );
+      });
+
+      test('detects Map<String, String> to Map<String, String?> as breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('Map<String, String> -> Map<String, String?>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening Map<String, String> to Map<String, String?> should be breaking for return types',
+        );
+      });
+
+      test('detects List<String> to List<String?> as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('List<String> -> List<String?>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening List<String> to List<String?> should be breaking for return types',
+        );
+      });
+
+      test('detects List<String> to List<dynamic> as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('List<String> -> List<dynamic>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening List<String> to List<dynamic> should be breaking for return types',
+        );
+      });
+
+      test('detects int to dynamic return type change as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('int -> dynamic') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason: 'Widening int to dynamic should be breaking for return types',
+        );
+      });
+
+      test(
+          'detects SomeSuperType to SomeSuperType? return type change as breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('SomeSuperType -> SomeSuperType?') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening SomeSuperType to SomeSuperType? should be breaking for return types',
         );
       });
     });

--- a/test/integration_tests/diff/test_package_return_type_changes_test.dart
+++ b/test/integration_tests/diff/test_package_return_type_changes_test.dart
@@ -1,0 +1,229 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  group('test_package_return_type_changes', () {
+    late PackageApiAnalyzer packageWithWideReturns;
+    late PackageApiAnalyzer packageWithNarrowReturns;
+
+    setUpAll(
+      () {
+        packageWithWideReturns = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'return_type_changes',
+          'package_with_wide_returns',
+        ));
+        packageWithNarrowReturns = PackageApiAnalyzer(
+            packagePath: path.join(
+          'test',
+          'test_packages',
+          'return_type_changes',
+          'package_with_narrow_returns',
+        ));
+      },
+    );
+
+    group('return type narrowing (should be non-breaking)', () {
+      late PackageApiDiffResult diffResult;
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageWithWideReturns.analyze(),
+          newApi: await packageWithNarrowReturns.analyze(),
+        );
+      });
+
+      test(
+          'detects nullable to non-nullable string return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('String? -> String') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing String? to String should be non-breaking for return types',
+        );
+      });
+
+      test('detects num to int return type change as non-breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('num -> int') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing num to int should be non-breaking for return types',
+        );
+      });
+
+      test('detects List<num> to List<int> return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('List<num> -> List<int>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing List<num> to List<int> should be non-breaking for return types',
+        );
+      });
+
+      test('detects Set<num> to Set<int> return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('Set<num> -> Set<int>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing Set<num> to Set<int> should be non-breaking for return types',
+        );
+      });
+
+      test(
+          'detects Iterable<num> to Iterable<int> return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription
+                    .contains('Iterable<num> -> Iterable<int>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing Iterable<num> to Iterable<int> should be non-breaking for return types',
+        );
+      });
+
+      test('detects supertype to subtype return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('SomeSuperType -> SomeSubType') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing supertype to subtype should be non-breaking for return types',
+        );
+      });
+
+      test(
+          'detects Iterable<num> to List<int> return type change as non-breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('Iterable<num> -> List<int>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isFalse,
+          reason:
+              'Narrowing Iterable<num> to List<int> should be non-breaking for return types (both base type and type parameter narrowing)',
+        );
+      });
+    });
+
+    group('return type widening (should be breaking)', () {
+      late PackageApiDiffResult diffResult;
+      setUpAll(() async {
+        diffResult = PackageApiDiffer().diff(
+          oldApi: await packageWithNarrowReturns.analyze(),
+          newApi: await packageWithWideReturns.analyze(),
+        );
+      });
+
+      test(
+          'detects non-nullable to nullable string return type change as breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('String -> String?') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening String to String? should be breaking for return types',
+        );
+      });
+
+      test('detects int to num return type change as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('int -> num') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason: 'Widening int to num should be breaking for return types',
+        );
+      });
+
+      test('detects List<int> to List<num> return type change as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('List<int> -> List<num>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening List<int> to List<num> should be breaking for return types',
+        );
+      });
+
+      test('detects subtype to supertype return type change as breaking', () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('SomeSubType -> SomeSuperType') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening subtype to supertype should be breaking for return types',
+        );
+      });
+
+      test('detects List<int> to Iterable<num> return type change as breaking',
+          () {
+        final returnTypeChange = diffResult.apiChanges
+            .where((ac) =>
+                ac.changeDescription.contains('List<int> -> Iterable<num>') &&
+                ac.changeDescription.contains('Return type changed'))
+            .single;
+        expect(
+          returnTypeChange.isBreaking,
+          isTrue,
+          reason:
+              'Widening List<int> to Iterable<num> should be breaking for return types (both base type and type parameter widening)',
+        );
+      });
+    });
+  });
+}

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/.gitignore
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/.gitignore
@@ -1,0 +1,6 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build output.
+build/

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/CHANGELOG.md
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/README.md
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/README.md
@@ -1,0 +1,3 @@
+# Package A - Narrow Return Types
+
+Test package with narrow return types for testing return type narrowing scenarios.

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/analysis_options.yaml
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/lib/package_a.dart
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/lib/package_a.dart
@@ -1,0 +1,4 @@
+/// Test package with narrow return types for return type narrowing tests.
+library package_a;
+
+export 'src/api_class.dart';

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/lib/src/api_class.dart
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/lib/src/api_class.dart
@@ -21,11 +21,33 @@ class ApiClass {
   /// Returns subtype (narrow type)
   SomeSubType getSuperType() => SomeSubType();
 
+  SomeSuperType getSuperType2() => SomeSuperType();
+
   /// Getter returning non-nullable string (narrow type)
   String get nullableStringGetter => "test";
 
   /// Getter returning specific integer (narrow type)
   int get generalNumberGetter => 42;
+
+  Map<String, String> returnAMap1() {
+    return {'key': 'value'};
+  }
+
+  Map<String, String> returnAMap2() {
+    return {'key': 'value'};
+  }
+
+  List<String> returnAList1() {
+    return ['value'];
+  }
+
+  List<String> returnAList2() {
+    return ['value'];
+  }
+
+  int returnSomething() {
+    return 1;
+  }
 }
 
 /// Base class for type hierarchy testing

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/lib/src/api_class.dart
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/lib/src/api_class.dart
@@ -1,0 +1,40 @@
+/// API class with narrow return types
+class ApiClass {
+  /// Returns non-nullable string (narrow type)
+  String nullableString() => "test";
+
+  /// Returns specific integer type (narrow type)
+  int generalNumber() => 42;
+
+  /// Returns list of specific integers (narrow type)
+  List<int> numberList() => [1, 2, 3];
+
+  /// Returns set of specific integers (narrow type)
+  Set<int> numberSet() => {1, 2, 3};
+
+  /// Returns iterable of specific integers (narrow type)
+  Iterable<int> numberIterable() => [1, 2, 3];
+
+  /// Returns list of specific integers (narrow base type and type parameter)
+  List<int> wideIterableToNarrowList() => [1, 2, 3];
+
+  /// Returns subtype (narrow type)
+  SomeSubType getSuperType() => SomeSubType();
+
+  /// Getter returning non-nullable string (narrow type)
+  String get nullableStringGetter => "test";
+
+  /// Getter returning specific integer (narrow type)
+  int get generalNumberGetter => 42;
+}
+
+/// Base class for type hierarchy testing
+class SomeSuperType {
+  String get name => "super";
+}
+
+/// Subclass for type hierarchy testing
+class SomeSubType extends SomeSuperType {
+  @override
+  String get name => "sub";
+}

--- a/test/test_packages/return_type_changes/package_with_narrow_returns/pubspec.yaml
+++ b/test/test_packages/return_type_changes/package_with_narrow_returns/pubspec.yaml
@@ -1,0 +1,10 @@
+name: package_a
+description: Test package with narrow return types for return type narrowing tests.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dev_dependencies: 
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/test/test_packages/return_type_changes/package_with_wide_returns/.gitignore
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/.gitignore
@@ -1,0 +1,6 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build output.
+build/

--- a/test/test_packages/return_type_changes/package_with_wide_returns/CHANGELOG.md
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/test/test_packages/return_type_changes/package_with_wide_returns/README.md
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/README.md
@@ -1,0 +1,3 @@
+# Package A - Wide Return Types
+
+Test package with wide return types for testing return type narrowing scenarios.

--- a/test/test_packages/return_type_changes/package_with_wide_returns/analysis_options.yaml
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/test/test_packages/return_type_changes/package_with_wide_returns/lib/package_a.dart
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/lib/package_a.dart
@@ -1,0 +1,4 @@
+/// Test package with wide return types for return type narrowing tests.
+library package_a;
+
+export 'src/api_class.dart';

--- a/test/test_packages/return_type_changes/package_with_wide_returns/lib/src/api_class.dart
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/lib/src/api_class.dart
@@ -1,0 +1,40 @@
+/// API class with wide return types
+class ApiClass {
+  /// Returns nullable string (wide type)
+  String? nullableString() => "test";
+
+  /// Returns general number type (wide type)
+  num generalNumber() => 42;
+
+  /// Returns list of general numbers (wide type)
+  List<num> numberList() => [1, 2, 3];
+
+  /// Returns set of general numbers (wide type)
+  Set<num> numberSet() => {1, 2, 3};
+
+  /// Returns iterable of general numbers (wide type)
+  Iterable<num> numberIterable() => [1, 2, 3];
+
+  /// Returns iterable of general numbers (wide base type and type parameter)
+  Iterable<num> wideIterableToNarrowList() => [1, 2, 3];
+
+  /// Returns supertype (wide type)
+  SomeSuperType getSuperType() => SomeSubType();
+
+  /// Getter returning nullable string (wide type)
+  String? get nullableStringGetter => "test";
+
+  /// Getter returning general number (wide type)
+  num get generalNumberGetter => 42;
+}
+
+/// Base class for type hierarchy testing
+class SomeSuperType {
+  String get name => "super";
+}
+
+/// Subclass for type hierarchy testing
+class SomeSubType extends SomeSuperType {
+  @override
+  String get name => "sub";
+}

--- a/test/test_packages/return_type_changes/package_with_wide_returns/lib/src/api_class.dart
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/lib/src/api_class.dart
@@ -21,11 +21,33 @@ class ApiClass {
   /// Returns supertype (wide type)
   SomeSuperType getSuperType() => SomeSubType();
 
+  SomeSuperType? getSuperType2() => SomeSuperType();
+
   /// Getter returning nullable string (wide type)
   String? get nullableStringGetter => "test";
 
   /// Getter returning general number (wide type)
   num get generalNumberGetter => 42;
+
+  Map<String, dynamic> returnAMap1() {
+    return {'key': 'value'};
+  }
+
+  Map<String, String?> returnAMap2() {
+    return {'key': 'value'};
+  }
+
+  List<dynamic> returnAList1() {
+    return ['value'];
+  }
+
+  List<String?> returnAList2() {
+    return ['value'];
+  }
+
+  dynamic returnSomething() {
+    return 1;
+  }
 }
 
 /// Base class for type hierarchy testing

--- a/test/test_packages/return_type_changes/package_with_wide_returns/pubspec.yaml
+++ b/test/test_packages/return_type_changes/package_with_wide_returns/pubspec.yaml
@@ -1,0 +1,10 @@
+name: package_a
+description: Test package with wide return types for return type narrowing tests.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.18.4 <3.0.0'
+
+dev_dependencies: 
+  lints: ^2.0.0
+  test: ^1.21.0


### PR DESCRIPTION
## Description
This PR is based on #222 
This PR fixes #221 

In this PR the TypeHierarchy that dart_apitool tracks gets extended to also understand generic types and their covariance.
This fixes return type change checks that led to breaking changes too fast (e.g. Iterable<num> -> List<int>)

## Type of Change
- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
