### PR TITLE
Fix weird protobuf changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   - Optional branch/tag/commit specification (e.g., git://https://github.com/user/repo:branch)
   - Automatic cloning, dependency resolution, and cleanup
   - Formats: git://https://github.com/user/repo or git://git@github.com:user/repo
-- fix: fix package name resolving for types referenced via a package-reference ('package:some_package/some_entrypoint.dart)
+- fix: package name resolving for types referenced via a package-reference ('package:some_package/some_entrypoint.dart)
+- fix: private top level methods where treated as part of the public API (resulting in all types used there treated as part of the public API as well)
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 0.22.1
+- feat: Support git references for package analysis
+  - Supports both HTTPS and SSH git repository formats
+  - Optional branch/tag/commit specification (e.g., git://https://github.com/user/repo:branch)
+  - Automatic cloning, dependency resolution, and cleanup
+  - Formats: git://https://github.com/user/repo or git://git@github.com:user/repo
+
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name
 - feat: add support for @internal annotations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Optional branch/tag/commit specification (e.g., git://https://github.com/user/repo:branch)
   - Automatic cloning, dependency resolution, and cleanup
   - Formats: git://https://github.com/user/repo or git://git@github.com:user/repo
+- fix: fix package name resolving for types referenced via a package-reference ('package:some_package/some_entrypoint.dart)
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Usage: dart-apitool extract [arguments]
                                            (e.g. /path/to/package)
                                          - any package from pub
                                            (e.g. pub://package_name/version)
+                                         - git repository with optional branch/tag/commit
+                                           (e.g. git://https://github.com/user/repo or git://https://github.com/user/repo:branch)
+                                           (e.g. git://git@github.com:user/repo or git://git@github.com:user/repo:tag)
 -p, --[no-]include-path-dependencies     OBSOLETE: Has no effect anymore.
     --output                             Output file for the extracted Package API.
                                          If not specified the extracted API will be printed to the console.
@@ -78,11 +81,17 @@ Usage: dart-apitool diff [arguments]
                                            (e.g. /path/to/package)
                                          - any package from pub
                                            (e.g. pub://package_name/version)
+                                         - git repository with optional branch/tag/commit
+                                           (e.g. git://https://github.com/user/repo or git://https://github.com/user/repo:branch)
+                                           (e.g. git://git@github.com:user/repo or git://git@github.com:user/repo:tag)
     --new (mandatory)                    New package reference. Package reference can be one of:
                                          - directory path pointing to a package on disk
                                            (e.g. /path/to/package)
                                          - any package from pub
                                            (e.g. pub://package_name/version)
+                                         - git repository with optional branch/tag/commit
+                                           (e.g. git://https://github.com/user/repo or git://https://github.com/user/repo:branch)
+                                           (e.g. git://git@github.com:user/repo or git://git@github.com:user/repo:tag)
 -p, --[no-]include-path-dependencies     OBSOLETE: Has no effect anymore.
     --version-check-mode                 Defines the mode the versions of the packages shall be compared. 
                                          This affects the exit code of this program.
@@ -110,6 +119,53 @@ Usage: dart-apitool diff [arguments]
 Run "dart-apitool help" to see global options.
 ```
 
+## Package References
+
+Dart API Tool supports three types of package references:
+
+### Directory Path
+Points directly to a package directory on your local filesystem:
+```bash
+dart-apitool extract --input /path/to/my/package
+```
+
+### Pub Package
+References a published package from pub.dev:
+```bash
+dart-apitool extract --input pub://package_name/1.0.0
+```
+If you omit the version, the latest version will be used:
+```bash
+dart-apitool extract --input pub://package_name
+```
+
+### Git Repository
+References a package directly from a git repository. Supports both HTTPS and SSH formats:
+
+**HTTPS format:**
+```bash
+# Clone the default branch
+dart-apitool extract --input git://https://github.com/user/repo
+
+# Clone a specific branch, tag, or commit
+dart-apitool extract --input git://https://github.com/user/repo:main
+dart-apitool extract --input git://https://github.com/user/repo:v1.0.0
+dart-apitool extract --input git://https://github.com/user/repo:abc123
+```
+
+**SSH format:**
+```bash
+# Clone the default branch
+dart-apitool extract --input git://git@github.com:user/repo
+
+# Clone a specific branch, tag, or commit
+dart-apitool extract --input git://git@github.com:user/repo:main
+dart-apitool extract --input git://git@github.com:user/repo:v1.0.0
+dart-apitool extract --input git://git@github.com:user/repo:abc123
+```
+
+Git repositories are automatically cloned to temporary directories and cleaned up after analysis. The tool will run `pub get` to ensure all dependencies are properly resolved.
+
 ## Integration
 
 How to best integrate `dart-apitool` in your CI and release process highly depends on your setup.
@@ -134,6 +190,28 @@ version="${tag#releases/}" # to support the old tag format dart_apitool used (e.
 version="${version#v}" # the new tag format (e.g. v0.12.0)
 ```
 You can see this in action in the [workflow](.github/workflows/ci.yml) of this repository. 
+
+### Git Repository Examples
+
+Git references are particularly useful when:
+- Comparing against unreleased changes in a development branch
+- Analyzing forks or private repositories
+- Working with packages not published to pub.dev
+
+**Compare current directory against a specific git tag:**
+```bash
+dart-apitool diff --old git://https://github.com/user/repo:v1.0.0 --new .
+```
+
+**Compare two different git branches:**
+```bash
+dart-apitool diff --old git://https://github.com/user/repo:main --new git://https://github.com/user/repo:develop
+```
+
+**Extract API from a private repository using SSH:**
+```bash
+dart-apitool extract --input git://git@github.com:company/private-repo:main --output api.json
+```
 
 For your convenience there is a reusable workflow that you can integrate in your workflow.
 ```yml

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -372,23 +372,25 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
 
   @override
   void visitTopLevelFunctionElement(TopLevelFunctionElement element) {
-    _onVisitFunctionElement(element);
-    super.visitTopLevelFunctionElement(element);
+    if (_onVisitFunctionElement(element)) {
+      super.visitTopLevelFunctionElement(element);
+    }
   }
 
   @override
   void visitLocalFunctionElement(LocalFunctionElement element) {
-    _onVisitFunctionElement(element);
-    super.visitLocalFunctionElement(element);
+    if (_onVisitFunctionElement(element)) {
+      super.visitLocalFunctionElement(element);
+    }
   }
 
-  void _onVisitFunctionElement(ExecutableElement2 element) {
+  bool _onVisitFunctionElement(ExecutableElement2 element) {
     _onVisitAnyElement(element);
     if (!_isElementAllowedToBeCollected(element)) {
-      return;
+      return false;
     }
     if (!_markElementAsCollected(element)) {
-      return;
+      return false;
     }
     _executableDeclarations
         .add(InternalExecutableDeclaration.fromExecutableElement(
@@ -400,6 +402,7 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
       _onTypeUsed(element.returnType, element,
           typeUsageKind: TypeUsageKind.output);
     }
+    return true;
   }
 
   @override

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -1,3 +1,4 @@
 export 'commands/commands.dart';
+export 'git_ref.dart';
 export 'package_ref.dart';
 export 'prepared_package_ref.dart';

--- a/lib/src/cli/git_ref.dart
+++ b/lib/src/cli/git_ref.dart
@@ -1,0 +1,198 @@
+/// Represents a parsed git reference from a package ref string
+///
+/// Handles parsing of git references in the format:
+/// - git://https://github.com/user/repo
+/// - git://https://github.com/user/repo:branch
+/// - git://https://github.com/user/repo/path/to/package:branch
+/// - git://git@github.com:user/repo
+/// - git://git@github.com:user/repo:tag
+/// - git://git@github.com:user/repo/path/to/package:tag
+class GitRef {
+  /// The git URI (without the git:// prefix, without the path, and without the branch/tag/commit)
+  final String uri;
+
+  /// The path within the repository (optional, for monorepos)
+  final String? path;
+
+  /// The branch, tag, or commit reference (optional)
+  final String? ref;
+
+  GitRef._({
+    required this.uri,
+    this.path,
+    this.ref,
+  });
+
+  /// Creates a GitRef from a package reference string
+  /// Returns null if the string is not a valid git reference
+  static GitRef? fromPackageRef(String packageRefString) {
+    if (!packageRefString.startsWith('git://')) {
+      return null;
+    }
+
+    // Remove the git:// prefix
+    final withoutScheme = packageRefString.substring(6);
+
+    // Handle git://https://... format
+    if (withoutScheme.startsWith('https://')) {
+      return _parseHttpsFormat(withoutScheme);
+    }
+
+    // Handle SSH format like git@github.com:user/repo or git@github.com:user/repo:branch
+    if (withoutScheme.contains('@')) {
+      return _parseSshFormat(withoutScheme);
+    }
+
+    // Fallback: treat the whole thing as a URI without ref
+    return GitRef._(uri: withoutScheme);
+  }
+
+  static GitRef _parseHttpsFormat(String withoutScheme) {
+    // Regex to parse HTTPS git URLs with optional path and ref
+    // Pattern: https://domain/user/repo(.git)?(/path/to/package)?(:ref)?
+    final httpsPattern = RegExp(
+        r'^(https://[^/]+/[^/]+/[^/:]+(?:\.git)?)((?:/[^:]+)?)?(?::(.+))?$');
+
+    final match = httpsPattern.firstMatch(withoutScheme);
+    if (match == null) {
+      // Fallback: treat the whole thing as a URI without ref
+      return GitRef._(uri: withoutScheme);
+    }
+
+    final uri = match.group(1)!; // https://domain/user/repo(.git)?
+    final pathPart = match.group(2); // /path/to/package or null
+    final ref = match.group(3); // ref or null
+
+    // Remove leading slash from path if present, and handle empty strings
+    final path = pathPart?.isNotEmpty == true && pathPart!.startsWith('/')
+        ? pathPart.substring(1)
+        : pathPart?.isNotEmpty == true
+            ? pathPart
+            : null;
+
+    return GitRef._(
+      uri: uri,
+      path: path,
+      ref: ref,
+    );
+  }
+
+  static GitRef _parseSshFormat(String withoutScheme) {
+    // Regex to parse SSH git URLs with optional path and ref
+    // Pattern: git@host:user/repo(.git)?(/path/to/package)?(:ref)?
+    final sshPattern = RegExp(
+        r'^([^@]+@[^:]+:[^/:]+/[^/:]+(?:\.git)?)((?:/[^:]+)?)?(?::(.+))?$');
+
+    final match = sshPattern.firstMatch(withoutScheme);
+    if (match == null) {
+      // Fallback for simple cases without ref or path
+      return GitRef._(uri: withoutScheme);
+    }
+
+    final uri = match.group(1)!; // git@host:user/repo(.git)?
+    final pathPart = match.group(2); // /path/to/package or null
+    final ref = match.group(3); // ref or null
+
+    // Remove leading slash from path if present, and handle empty strings
+    final path = pathPart?.isNotEmpty == true && pathPart!.startsWith('/')
+        ? pathPart.substring(1)
+        : pathPart?.isNotEmpty == true
+            ? pathPart
+            : null;
+
+    return GitRef._(
+      uri: uri,
+      path: path,
+      ref: ref,
+    );
+  }
+
+  /// Creates a string representation for internal use (e.g., in SourceItem)
+  String toInternalString() {
+    final pathPart = path != null ? '/$path' : '';
+    return 'GIT:$uri$pathPart${ref != null ? ':$ref' : ':HEAD'}';
+  }
+
+  /// Creates a GitRef from an internal string representation
+  static GitRef fromInternalString(String internalString) {
+    if (!internalString.startsWith('GIT:')) {
+      throw ArgumentError('Invalid internal git ref string: $internalString');
+    }
+
+    final withoutPrefix = internalString.substring(4); // Remove 'GIT:'
+
+    // Find the last colon to separate ref from URI+path
+    final lastColonIndex = withoutPrefix.lastIndexOf(':');
+    if (lastColonIndex == -1) {
+      throw ArgumentError('Invalid internal git ref string: $internalString');
+    }
+
+    final uriWithPath = withoutPrefix.substring(0, lastColonIndex);
+    final refPart = withoutPrefix.substring(lastColonIndex + 1);
+    final actualRef = refPart == 'HEAD' ? null : refPart;
+
+    // Parse URI and path using regex
+    String uri;
+    String? path;
+
+    if (uriWithPath.startsWith('https://')) {
+      final httpsPattern =
+          RegExp(r'^(https://[^/]+/[^/]+/[^/]+(?:\.git)?)((?:/.+)?)$');
+      final match = httpsPattern.firstMatch(uriWithPath);
+      if (match != null) {
+        uri = match.group(1)!;
+        final pathPart = match.group(2);
+        path = pathPart?.isNotEmpty == true && pathPart!.startsWith('/')
+            ? pathPart.substring(1)
+            : pathPart?.isNotEmpty == true
+                ? pathPart
+                : null;
+      } else {
+        uri = uriWithPath;
+        path = null;
+      }
+    } else if (uriWithPath.contains('@')) {
+      final sshPattern =
+          RegExp(r'^([^@]+@[^:]+:[^/]+/[^/]+(?:\.git)?)((?:/.+)?)$');
+      final match = sshPattern.firstMatch(uriWithPath);
+      if (match != null) {
+        uri = match.group(1)!;
+        final pathPart = match.group(2);
+        path = pathPart?.isNotEmpty == true && pathPart!.startsWith('/')
+            ? pathPart.substring(1)
+            : pathPart?.isNotEmpty == true
+                ? pathPart
+                : null;
+      } else {
+        uri = uriWithPath;
+        path = null;
+      }
+    } else {
+      uri = uriWithPath;
+      path = null;
+    }
+
+    return GitRef._(uri: uri, path: path, ref: actualRef);
+  }
+
+  @override
+  String toString() {
+    final pathPart = path != null ? '/$path' : '';
+    if (ref != null) {
+      return '$uri$pathPart:$ref';
+    }
+    return '$uri$pathPart';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is GitRef &&
+        other.uri == uri &&
+        other.path == path &&
+        other.ref == ref;
+  }
+
+  @override
+  int get hashCode => Object.hash(uri, path, ref);
+}

--- a/lib/src/cli/package_ref.dart
+++ b/lib/src/cli/package_ref.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'git_ref.dart';
+
 /// representation of a package reference
 ///
 /// a [PackageRef] can be:
@@ -26,6 +28,16 @@ class PackageRef {
     return uri.hasScheme && uri.scheme == 'pub';
   }
 
+  /// determines if this reference references a git repository
+  /// Formats:
+  /// - git://some_ssh_git_ref
+  /// - git://some_ssh_git_ref:`<branch, tag or commit>`
+  /// - git://https://some_http_git_ref
+  /// - git://https://some_http_git_ref:`<branch, tag or commit>`
+  bool get isGitRef {
+    return ref.startsWith('git://');
+  }
+
   /// (only valid if [isPubRef]) gets the package name from the pub ref
   String? get pubPackage {
     if (!isPubRef) {
@@ -48,6 +60,25 @@ class PackageRef {
     return path;
   }
 
+  /// (only valid if [isGitRef]) gets the parsed git reference
+  GitRef? get gitRef {
+    if (!isGitRef) {
+      return null;
+    }
+    return GitRef.fromPackageRef(ref);
+  }
+
+  /// (only valid if [isGitRef]) gets the git URI from the git ref
+  /// Removes the git:// scheme and extracts the actual git URL
+  String? get gitUri {
+    return gitRef?.uri;
+  }
+
+  /// (only valid if [isGitRef]) gets the branch, tag, or commit from the git ref
+  String? get gitRefString {
+    return gitRef?.ref;
+  }
+
   @override
   String toString() {
     var kind = 'Unknown';
@@ -55,6 +86,8 @@ class PackageRef {
       kind = 'Directory';
     } else if (isPubRef) {
       kind = 'Pub ref';
+    } else if (isGitRef) {
+      kind = 'Git ref';
     }
     return '$ref ($kind)';
   }

--- a/lib/src/tooling/git_interaction.dart
+++ b/lib/src/tooling/git_interaction.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import '../utils/stdout_session.dart';
+
+abstract class GitInteraction {
+  /// Clones a git repository to the specified directory
+  /// Returns the path to the package directory (which may be a subdirectory if path is specified)
+  static Future<String> cloneRepositoryToDirectory(
+    String gitUri,
+    String targetDirectory,
+    String? ref, // branch, tag, or commit
+    String? path, // subdirectory path within the repository
+    {
+    StdoutSession? stdoutSession,
+  }) async {
+    final session = stdoutSession ?? StdoutSession();
+
+    await session.writeln('Cloning git repository: $gitUri');
+
+    // Always clone without specifying a branch first
+    final cloneArgs = ['clone', gitUri, targetDirectory];
+
+    final cloneResult = await Process.run('git', cloneArgs);
+    if (cloneResult.exitCode != 0) {
+      throw Exception('Failed to clone repository: ${cloneResult.stderr}');
+    }
+
+    // If ref is specified, checkout the specific ref (branch, tag, or commit)
+    if (ref != null) {
+      await session.writeln('Checking out ref: $ref');
+      final checkoutResult = await Process.run(
+        'git',
+        ['checkout', ref],
+        workingDirectory: targetDirectory,
+      );
+      if (checkoutResult.exitCode != 0) {
+        throw Exception('Failed to checkout $ref: ${checkoutResult.stderr}');
+      }
+    }
+
+    // Determine the final package directory
+    final packageDirectory =
+        path != null ? p.join(targetDirectory, path) : targetDirectory;
+
+    // Verify that the package directory exists
+    if (!await Directory(packageDirectory).exists()) {
+      throw Exception('Package directory not found: $packageDirectory');
+    }
+
+    // Verify that it contains a pubspec.yaml
+    final pubspecFile = File(p.join(packageDirectory, 'pubspec.yaml'));
+    if (!await pubspecFile.exists()) {
+      throw Exception(
+          'No pubspec.yaml found in package directory: $packageDirectory');
+    }
+
+    await session.writeln('Successfully cloned to: $targetDirectory');
+    if (path != null) {
+      await session.writeln('Package directory: $packageDirectory');
+    }
+
+    return packageDirectory;
+  }
+}

--- a/lib/src/tooling/tooling.dart
+++ b/lib/src/tooling/tooling.dart
@@ -1,2 +1,3 @@
 export 'pub_interaction.dart';
 export 'dart_interaction.dart';
+export 'git_interaction.dart';

--- a/test/integration_tests/cli/diff_command_test.dart
+++ b/test/integration_tests/cli/diff_command_test.dart
@@ -163,5 +163,25 @@ void main() {
       },
       timeout: integrationTestTimeout,
     );
+
+    test(
+      'diffing protobuf 4916e6f7d34443869c27d997749d4362870fd7ce to protobuf 7f7d776a1812594b0d2b56bac41439f50006e225 works',
+      () async {
+        // just some random package that we know the git refs of
+        final diffCommand = DiffCommand();
+        final runner =
+            CommandRunner<int>('dart_apitool_tests', 'Test for dart_apitool')
+              ..addCommand(diffCommand);
+        final exitCode = await runner.run([
+          'diff',
+          '--old',
+          'git://https://github.com/google/protobuf.dart.git/protobuf:4916e6f7d34443869c27d997749d4362870fd7ce',
+          '--new',
+          'git://https://github.com/google/protobuf.dart.git/protobuf:7f7d776a1812594b0d2b56bac41439f50006e225',
+        ]);
+        expect(exitCode, 0);
+      },
+      timeout: integrationTestTimeout,
+    );
   });
 }

--- a/test/integration_tests/cli/diff_command_test.dart
+++ b/test/integration_tests/cli/diff_command_test.dart
@@ -165,7 +165,7 @@ void main() {
     );
 
     test(
-      'diffing protobuf 4916e6f7d34443869c27d997749d4362870fd7ce to protobuf 7f7d776a1812594b0d2b56bac41439f50006e225 works',
+      'diffing protobuf a9822d881d27a27b454621bc698997fce5abf370 to 4916e6f7d34443869c27d997749d4362870fd7ce works',
       () async {
         // just some random package that we know the git refs of
         final diffCommand = DiffCommand();
@@ -175,9 +175,9 @@ void main() {
         final exitCode = await runner.run([
           'diff',
           '--old',
-          'git://https://github.com/google/protobuf.dart.git/protobuf:4916e6f7d34443869c27d997749d4362870fd7ce',
+          'git://https://github.com/google/protobuf.dart.git/protobuf:a9822d881d27a27b454621bc698997fce5abf370',
           '--new',
-          'git://https://github.com/google/protobuf.dart.git/protobuf:7f7d776a1812594b0d2b56bac41439f50006e225',
+          'git://https://github.com/google/protobuf.dart.git/protobuf:4916e6f7d34443869c27d997749d4362870fd7ce',
         ]);
         expect(exitCode, 0);
       },

--- a/test/integration_tests/diff/protobuf_git_test.dart
+++ b/test/integration_tests/diff/protobuf_git_test.dart
@@ -1,14 +1,3 @@
-/*
-
-            "args": [
-                "diff",
-                "--old",
-                "git://https://github.com/google/protobuf.dart.git/protobuf:4916e6f7d34443869c27d997749d4362870fd7ce",
-                "--new",
-                "git://https://github.com/google/protobuf.dart.git/protobuf:7f7d776a1812594b0d2b56bac41439f50006e225"
-            ]
-
-*/
 import 'package:dart_apitool/api_tool.dart';
 import 'package:test/test.dart';
 

--- a/test/integration_tests/diff/protobuf_git_test.dart
+++ b/test/integration_tests/diff/protobuf_git_test.dart
@@ -1,0 +1,72 @@
+/*
+
+            "args": [
+                "diff",
+                "--old",
+                "git://https://github.com/google/protobuf.dart.git/protobuf:4916e6f7d34443869c27d997749d4362870fd7ce",
+                "--new",
+                "git://https://github.com/google/protobuf.dart.git/protobuf:7f7d776a1812594b0d2b56bac41439f50006e225"
+            ]
+
+*/
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+
+import '../helper/integration_test_helper.dart';
+
+void main() {
+  group('protobuf version diff', () {
+    group(
+        '4916e6f7d34443869c27d997749d4362870fd7ce to 7f7d776a1812594b0d2b56bac41439f50006e225',
+        () {
+      final retrieverOld = GitPackageApiRetriever(
+          'https://github.com/google/protobuf.dart.git',
+          '4916e6f7d34443869c27d997749d4362870fd7ce',
+          relativePackagePath: 'protobuf');
+      final retrieverNew = GitPackageApiRetriever(
+          'https://github.com/google/protobuf.dart.git',
+          '7f7d776a1812594b0d2b56bac41439f50006e225',
+          relativePackagePath: 'protobuf');
+
+      late PackageApiDiffResult diffResult;
+      late PackageApi oldApi;
+      late PackageApi newApi;
+
+      setUpAll(() async {
+        oldApi = await retrieverOld.retrieve();
+        newApi = await retrieverNew.retrieve();
+        diffResult = PackageApiDiffer().diff(oldApi: oldApi, newApi: newApi);
+      });
+
+      test('does not report changes from type X to type X', () {
+        // Check for any changes that report a type change from X to X (same type)
+        final identicalTypeChanges = diffResult.apiChanges.where((change) {
+          final description = change.changeDescription;
+
+          // Look for pattern: "changed. TypeX -> TypeX" where TypeX is identical
+          final typeChangePattern =
+              RegExp(r'changed\.\s*(.+?)\s*->\s*(.+?)(?:\s|$)');
+          final match = typeChangePattern.firstMatch(description);
+
+          if (match != null) {
+            final oldType = match.group(1)?.trim();
+            final newType = match.group(2)?.trim();
+            return oldType == newType && oldType != null && oldType.isNotEmpty;
+          }
+
+          return false;
+        }).toList();
+
+        // Print all identical type changes for debugging
+        for (final change in identicalTypeChanges) {
+          print(
+              'Found identical type change: ${change.changeDescription} (${change.changeCode})');
+        }
+
+        expect(identicalTypeChanges, isEmpty,
+            reason:
+                'Found ${identicalTypeChanges.length} changes that report type changes from X to X');
+      });
+    });
+  });
+}

--- a/test/integration_tests/helper/integration_test_helper.dart
+++ b/test/integration_tests/helper/integration_test_helper.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dart_apitool/api_tool.dart';
 import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
 
 class PackageApiRetriever {
   final String packageName;
@@ -32,11 +33,13 @@ class PackageApiRetriever {
 class GitPackageApiRetriever {
   final String gitUrl;
   final String gitRef;
+  final String? relativePackagePath;
   final bool doConsiderNonSrcAsEntryPoints;
 
   GitPackageApiRetriever(
     this.gitUrl,
     this.gitRef, {
+    this.relativePackagePath,
     this.doConsiderNonSrcAsEntryPoints = false,
   });
 
@@ -55,8 +58,13 @@ class GitPackageApiRetriever {
       throw Exception('Unable to check out $gitRef of git repository $gitUrl');
     }
 
+    String packagePath = tempDir.path;
+    if (relativePackagePath != null) {
+      packagePath = p.join(tempDir.path, relativePackagePath);
+    }
+
     final analyzer = PackageApiAnalyzer(
-      packagePath: tempDir.path,
+      packagePath: packagePath,
       doConsiderNonSrcAsEntryPoints: doConsiderNonSrcAsEntryPoints,
     );
     print('Analyzing $gitUrl $gitRef');

--- a/test/unit_tests/cli/git_ref_test.dart
+++ b/test/unit_tests/cli/git_ref_test.dart
@@ -1,0 +1,225 @@
+import 'package:test/test.dart';
+import 'package:dart_apitool/src/cli/git_ref.dart';
+
+void main() {
+  group('GitRef', () {
+    group('fromPackageRef', () {
+      test('should return null for non-git references', () {
+        expect(GitRef.fromPackageRef('pub://package_name'), isNull);
+        expect(GitRef.fromPackageRef('/local/path'), isNull);
+        expect(GitRef.fromPackageRef('https://github.com/user/repo'), isNull);
+      });
+
+      group('HTTPS format', () {
+        test('should parse basic HTTPS git reference without branch', () {
+          final gitRef =
+              GitRef.fromPackageRef('git://https://github.com/user/repo');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('https://github.com/user/repo'));
+          expect(gitRef.path, isNull);
+          expect(gitRef.ref, isNull);
+        });
+
+        test('should parse HTTPS git reference with branch', () {
+          final gitRef =
+              GitRef.fromPackageRef('git://https://github.com/user/repo:main');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('https://github.com/user/repo'));
+          expect(gitRef.path, isNull);
+          expect(gitRef.ref, equals('main'));
+        });
+
+        test('should parse HTTPS git reference with .git suffix', () {
+          final gitRef = GitRef.fromPackageRef(
+              'git://https://github.com/google/protobuf.dart.git:commit');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri,
+              equals('https://github.com/google/protobuf.dart.git'));
+          expect(gitRef.path, isNull);
+          expect(gitRef.ref, equals('commit'));
+        });
+
+        test('should parse HTTPS git reference with .git suffix and path', () {
+          final gitRef = GitRef.fromPackageRef(
+              'git://https://github.com/google/protobuf.dart.git/protobuf:commit');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri,
+              equals('https://github.com/google/protobuf.dart.git'));
+          expect(gitRef.path, equals('protobuf'));
+          expect(gitRef.ref, equals('commit'));
+        });
+
+        test('should parse HTTPS git reference with path without .git', () {
+          final gitRef = GitRef.fromPackageRef(
+              'git://https://github.com/user/repo/path/to/package:main');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('https://github.com/user/repo'));
+          expect(gitRef.path, equals('path/to/package'));
+          expect(gitRef.ref, equals('main'));
+        });
+
+        test('should parse long commit hash', () {
+          final gitRef = GitRef.fromPackageRef(
+              'git://https://github.com/google/protobuf.dart.git:4916e6f7d34443869c27d997749d4362870fd7ce');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri,
+              equals('https://github.com/google/protobuf.dart.git'));
+          expect(gitRef.path, isNull);
+          expect(
+              gitRef.ref, equals('4916e6f7d34443869c27d997749d4362870fd7ce'));
+        });
+      });
+
+      group('SSH format', () {
+        test('should parse basic SSH git reference without branch', () {
+          final gitRef =
+              GitRef.fromPackageRef('git://git@github.com:user/repo');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('git@github.com:user/repo'));
+          expect(gitRef.path, isNull);
+          expect(gitRef.ref, isNull);
+        });
+
+        test('should parse SSH git reference with branch', () {
+          final gitRef =
+              GitRef.fromPackageRef('git://git@github.com:user/repo:main');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('git@github.com:user/repo'));
+          expect(gitRef.path, isNull);
+          expect(gitRef.ref, equals('main'));
+        });
+
+        test('should parse SSH git reference with path', () {
+          final gitRef = GitRef.fromPackageRef(
+              'git://git@github.com:user/repo/path/to/package:v1.0.0');
+          expect(gitRef, isNotNull);
+          expect(gitRef!.uri, equals('git@github.com:user/repo'));
+          expect(gitRef.path, equals('path/to/package'));
+          expect(gitRef.ref, equals('v1.0.0'));
+        });
+      });
+    });
+
+    group('toString', () {
+      test('should create string representation without ref', () {
+        final gitRef =
+            GitRef.fromPackageRef('git://https://github.com/user/repo');
+        expect(gitRef.toString(), equals('https://github.com/user/repo'));
+      });
+
+      test('should create string representation with ref', () {
+        final gitRef =
+            GitRef.fromPackageRef('git://https://github.com/user/repo:main');
+        expect(gitRef.toString(), equals('https://github.com/user/repo:main'));
+      });
+
+      test('should create string representation with path and ref', () {
+        final gitRef = GitRef.fromPackageRef(
+            'git://https://github.com/user/repo/path/to/package:main');
+        expect(gitRef.toString(),
+            equals('https://github.com/user/repo/path/to/package:main'));
+      });
+    });
+
+    group('toInternalString', () {
+      test('should create internal string representation without ref', () {
+        final gitRef =
+            GitRef.fromPackageRef('git://https://github.com/user/repo');
+        expect(gitRef!.toInternalString(),
+            equals('GIT:https://github.com/user/repo:HEAD'));
+      });
+
+      test('should create internal string representation with ref', () {
+        final gitRef =
+            GitRef.fromPackageRef('git://https://github.com/user/repo:main');
+        expect(gitRef!.toInternalString(),
+            equals('GIT:https://github.com/user/repo:main'));
+      });
+
+      test('should create internal string representation with path and ref',
+          () {
+        final gitRef = GitRef.fromPackageRef(
+            'git://https://github.com/user/repo/path/to/package:main');
+        expect(gitRef!.toInternalString(),
+            equals('GIT:https://github.com/user/repo/path/to/package:main'));
+      });
+    });
+
+    group('fromInternalString', () {
+      test('should parse internal string representation', () {
+        final gitRef =
+            GitRef.fromInternalString('GIT:https://github.com/user/repo:main');
+        expect(gitRef.uri, equals('https://github.com/user/repo'));
+        expect(gitRef.path, isNull);
+        expect(gitRef.ref, equals('main'));
+      });
+
+      test('should parse internal string representation with HEAD', () {
+        final gitRef =
+            GitRef.fromInternalString('GIT:https://github.com/user/repo:HEAD');
+        expect(gitRef.uri, equals('https://github.com/user/repo'));
+        expect(gitRef.path, isNull);
+        expect(gitRef.ref, isNull);
+      });
+
+      test('should parse internal string representation with path', () {
+        final gitRef = GitRef.fromInternalString(
+            'GIT:https://github.com/user/repo/path/to/package:main');
+        expect(gitRef.uri, equals('https://github.com/user/repo'));
+        expect(gitRef.path, equals('path/to/package'));
+        expect(gitRef.ref, equals('main'));
+      });
+
+      test('should throw on invalid internal string', () {
+        expect(() => GitRef.fromInternalString('invalid'), throwsArgumentError);
+        expect(() => GitRef.fromInternalString('GIT:invalid'),
+            throwsArgumentError);
+      });
+    });
+
+    group('round-trip conversion', () {
+      test('should maintain equality through toString and fromPackageRef', () {
+        final testCases = [
+          'git://https://github.com/user/repo',
+          'git://https://github.com/user/repo:main',
+          'git://https://github.com/user/repo/path/to/package:main',
+          'git://git@github.com:user/repo:main',
+          'git://git@github.com:user/repo/path/to/package:v1.0.0',
+          'git://https://github.com/google/protobuf.dart.git:4916e6f7d34443869c27d997749d4362870fd7ce',
+          'git://https://github.com/google/protobuf.dart.git/protobuf:commit',
+        ];
+
+        for (final testCase in testCases) {
+          final gitRef = GitRef.fromPackageRef(testCase);
+          expect(gitRef, isNotNull, reason: 'Failed to parse: $testCase');
+
+          final roundTrip = GitRef.fromPackageRef('git://${gitRef.toString()}');
+          expect(roundTrip, equals(gitRef),
+              reason: 'Round-trip failed for: $testCase');
+        }
+      });
+
+      test(
+          'should maintain equality through toInternalString and fromInternalString',
+          () {
+        final testCases = [
+          'git://https://github.com/user/repo',
+          'git://https://github.com/user/repo:main',
+          'git://https://github.com/user/repo/path/to/package:main',
+          'git://git@github.com:user/repo:main',
+          'git://git@github.com:user/repo/path/to/package:v1.0.0',
+        ];
+
+        for (final testCase in testCases) {
+          final gitRef = GitRef.fromPackageRef(testCase);
+          expect(gitRef, isNotNull, reason: 'Failed to parse: $testCase');
+
+          final internalString = gitRef!.toInternalString();
+          final roundTrip = GitRef.fromInternalString(internalString);
+          expect(roundTrip, equals(gitRef),
+              reason: 'Internal round-trip failed for: $testCase');
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Wohoo! 🥳 Thanks for contributing! The coding part is Done. Now lets get some reviews!
  Please provide a description and fill in the checklist to ensure that your PR can be accepted quickly.
-->

## Description
in a PR of protobuf there were some hints of weird dart_apitool behavior (https://github.com/google/protobuf.dart/pull/1026)
The main issue was that parameter type changes are detected that are none (TypeX changed to TypeX)

To investigate this issue more easily I also added git support for the package ref (solving #204 ).
And while trying get rid of all wrong changes I also fixed (parts of) https://github.com/bmw-tech/dart_apitool/issues/228 (private top level functions). I still need to check for other private types, though.

There were two major issues that are now fixed:
1. the package resolution was no longer working for package refs ('package:xxx/yyy.dart') always falling back to the "file name without extension". In the protobuf case the entry point changed from "protobuf.dart" to "internal.dart" for a couple of types and for all of those types dart_apitool detected a package change (protobuf -> internal) which is wrong. This PR adds support for package refs and also turns file URIs into file paths before looking for the pubspec.yaml
2. private top level functions were considered part of the public API (the method `_onVisitFunctionElement` did the right checks but this method was also used for top level and local functions that called into their super method of the RecursiveElementVisitor making it iterating through all parameters regardless

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
