### PR TITLE
fix: don't use terminal colors when StdioType is not Terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Formats: git://https://github.com/user/repo or git://git@github.com:user/repo
 - fix: package name resolving for types referenced via a package-reference ('package:some_package/some_entrypoint.dart)
 - fix: private top level methods where treated as part of the public API (resulting in all types used there treated as part of the public API as well)
+- fix: don't print color control sequences when no terminal is attached (e.g. when piping the output to a file)
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Formats: git://https://github.com/user/repo or git://git@github.com:user/repo
 - fix: package name resolving for types referenced via a package-reference ('package:some_package/some_entrypoint.dart)
 - fix: private top level methods where treated as part of the public API (resulting in all types used there treated as part of the public API as well)
-- fix: don't print color control sequences when no terminal is attached (e.g. when piping the output to a file)
+- fix: don't print color control sequences if no terminal is attached (e.g. when piping the output to a file)
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -3,7 +3,6 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:colorize/colorize.dart';
 import 'package:colorize_lumberdash/colorize_lumberdash.dart';
 import 'package:dart_apitool/api_tool_cli.dart';
 import 'package:lumberdash/lumberdash.dart';
@@ -11,7 +10,7 @@ import 'package:lumberdash/lumberdash.dart';
 void main(List<String> arguments) async {
   putLumberdashToWork(withClients: [ColorizeLumberdash()]);
   final runner = CommandRunner<int>('dart-apitool', '''
-dart-apitool (${Colorize(await getOwnVersion()).bold()})
+dart-apitool (${ColorUtils.bold(await getOwnVersion())})
 
 A set of utilities for Package APIs.
 ''')
@@ -28,14 +27,8 @@ A set of utilities for Package APIs.
     final exitCode = await runner.run(arguments);
     exit(exitCode ?? -1);
   } catch (e) {
-    bool colorize = true;
-    if (e is UsageException) {
-      colorize = false;
-    }
-    final errorMessage =
-        colorize ? Colorize(e.toString()).red() : Colorize(e.toString());
-    final errorPrefix =
-        colorize ? Colorize('Error:').red().bold() : Colorize('Error:');
+    final errorMessage = ColorUtils.redError(e.toString());
+    final errorPrefix = ColorUtils.boldRedError('Error:');
     stderr.writeln('$errorPrefix $errorMessage');
     exit(1);
   }

--- a/lib/src/diff/report/console_diff_reporter.dart
+++ b/lib/src/diff/report/console_diff_reporter.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:colorize/colorize.dart';
 import 'package:console/console.dart';
 
 import '../../../api_tool.dart';
@@ -40,9 +39,9 @@ class ConsoleDiffReporter extends DiffReporter {
     if (versionCheckResult != null) {
       stdout.writeln('Version Check');
       if (versionCheckResult.success) {
-        stdout.writeln(Colorize('New version is OK!').green());
+        stdout.writeln(ColorUtils.green('New version is OK!'));
       } else {
-        stdout.writeln(Colorize('New Version is too low!').red());
+        stdout.writeln(ColorUtils.red('New Version is too low!'));
       }
       stdout.writeln();
       stdout.writeln('Old version: "${versionCheckResult.oldVersion}"');
@@ -59,7 +58,7 @@ class ConsoleDiffReporter extends DiffReporter {
     Map nodeToTree(ApiChangeTreeNode n, {String? labelOverride}) {
       final relevantChanges = n.changes.where((c) => c.isBreaking == breaking);
       final changeNodes = relevantChanges.map((c) =>
-          '${Colorize(c.changeDescription).italic()} (${c.changeCode.code})${c.isBreaking ? '' : c.type.requiresMinorBump ? ' (minor)' : ' (patch)'}');
+          '${ColorUtils.italic(c.changeDescription)} (${c.changeCode.code})${c.isBreaking ? '' : c.type.requiresMinorBump ? ' (minor)' : ' (patch)'}');
       final childNodes = n.children.values
           .map((value) => nodeToTree(value))
           .where((element) => element.isNotEmpty);
@@ -67,12 +66,10 @@ class ConsoleDiffReporter extends DiffReporter {
       return allChildren.isEmpty
           ? {}
           : {
-              'label': Colorize(labelOverride ??
-                      (n.nodeDeclaration == null
-                          ? ''
-                          : getDeclarationNodeHeadline(n.nodeDeclaration!)))
-                  .bold()
-                  .toString(),
+              'label': ColorUtils.bold(labelOverride ??
+                  (n.nodeDeclaration == null
+                      ? ''
+                      : getDeclarationNodeHeadline(n.nodeDeclaration!))),
               'nodes': allChildren,
             };
     }

--- a/lib/src/utils/color_utils.dart
+++ b/lib/src/utils/color_utils.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:colorize/colorize.dart';
+
+/// Utility class for handling colored terminal output.
+/// Automatically detects if stdout/stderr are attached to a terminal
+/// and disables colors when output is piped to a file.
+class ColorUtils {
+  /// Whether colors should be enabled for stdout
+  static bool get shouldUseColorsForStdout =>
+      stdioType(stdout) == StdioType.terminal;
+
+  /// Whether colors should be enabled for stderr
+  static bool get shouldUseColorsForStderr =>
+      stdioType(stderr) == StdioType.terminal;
+
+  /// Creates a colorized string for stdout output.
+  /// If stdout is not a terminal, returns the plain text without colors.
+  static String colorizeForStdout(
+      String text, Colorize Function(Colorize) style) {
+    if (shouldUseColorsForStdout) {
+      return style(Colorize(text)).toString();
+    }
+    return text;
+  }
+
+  /// Creates a colorized string for stderr output.
+  /// If stderr is not a terminal, returns the plain text without colors.
+  static String colorizeForStderr(
+      String text, Colorize Function(Colorize) style) {
+    if (shouldUseColorsForStderr) {
+      return style(Colorize(text)).toString();
+    }
+    return text;
+  }
+
+  /// Convenience method for green text on stdout
+  static String green(String text) => colorizeForStdout(text, (c) => c.green());
+
+  /// Convenience method for red text on stdout
+  static String red(String text) => colorizeForStdout(text, (c) => c.red());
+
+  /// Convenience method for bold text on stdout
+  static String bold(String text) => colorizeForStdout(text, (c) => c.bold());
+
+  /// Convenience method for italic text on stdout
+  static String italic(String text) =>
+      colorizeForStdout(text, (c) => c.italic());
+
+  /// Convenience method for red text on stderr
+  static String redError(String text) =>
+      colorizeForStderr(text, (c) => c.red());
+
+  /// Convenience method for bold red text on stderr
+  static String boldRedError(String text) =>
+      colorizeForStderr(text, (c) => c.red().bold());
+}

--- a/lib/src/utils/stdout_session.dart
+++ b/lib/src/utils/stdout_session.dart
@@ -15,6 +15,9 @@ class StdoutSession {
 
   Completer<void>? _writeCompleter;
 
+  /// Whether colors should be used based on whether stdout is a terminal
+  bool get _shouldUseColors => stdioType(stdout) == StdioType.terminal;
+
   /// writes the given [bytes] to the console
   Future write(List<int> bytes) async {
     // make sure that only one write is active at a time (needed for flush to work)
@@ -75,7 +78,9 @@ class StdoutSession {
     if (_lastDrawnWindowSize != null) {
       Console.moveCursorUp(_lastDrawnWindowSize!);
     }
-    Console.setTextColor(Color.GRAY.id);
+    if (_shouldUseColors) {
+      Console.setTextColor(Color.GRAY.id);
+    }
     _lastDrawnWindowSize = _windowLines.length;
     for (var i = 0; i < _windowLines.length; i++) {
       Console.eraseLine(2);
@@ -85,6 +90,8 @@ class StdoutSession {
       Console.moveCursorDown();
       Console.moveToColumn(0);
     }
-    Console.resetTextColor();
+    if (_shouldUseColors) {
+      Console.resetTextColor();
+    }
   }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,3 +1,4 @@
+export 'color_utils.dart';
 export 'declaration_utils.dart';
 export 'naming_utils.dart';
 export 'process_utils.dart';


### PR DESCRIPTION
## Description
This PR fixes issue #229 by not using color control sequences when not attached to a terminal

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
