### PR TITLE
fix: hidden top level functions shall not be part of the public API

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.32.1",
+  "flutter": "3.32.8",
   "flavors": {}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.32.1",
+  "dart.flutterSdkPath": ".fvm/versions/3.32.8",
   "dart.sdkPath": ".fvm/flutter_sdk/bin/cache/dart-sdk",
   "search.exclude": {
     "**/.fvm": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix: don't print color control sequences if no terminal is attached (e.g. when piping the output to a file)
 - fix: carry over entry points of type aliases to the aliased type (especially important for private types)
 - fix: naming of unary operators was wrong (unaryunary...)
+- fix: handling of top level functions in the context of show / hide in exports
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/lib/src/analyze/api_relevant_elements_collector.dart
+++ b/lib/src/analyze/api_relevant_elements_collector.dart
@@ -313,6 +313,9 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
   @override
   visitTopLevelVariableElement(TopLevelVariableElement2 element) {
     _onVisitAnyElement(element);
+    if (element.name3 != null && !_isNameExported(element.name3!)) {
+      return;
+    }
     if (!_isElementAllowedToBeCollected(element)) {
       return;
     }
@@ -372,6 +375,9 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
 
   @override
   void visitTopLevelFunctionElement(TopLevelFunctionElement element) {
+    if (element.name3 != null && !_isNameExported(element.name3!)) {
+      return;
+    }
     if (_onVisitFunctionElement(element)) {
       super.visitTopLevelFunctionElement(element);
     }
@@ -427,6 +433,9 @@ class APIRelevantElementsCollector extends RecursiveElementVisitor2<void> {
   @override
   visitTypeAliasElement(TypeAliasElement2 element) {
     _onVisitAnyElement(element);
+    if (element.name3 != null && !_isNameExported(element.name3!)) {
+      return;
+    }
     if (!_isElementAllowedToBeCollected(element)) {
       return;
     }

--- a/test/integration_tests/analyze/grpc_dart_test.dart
+++ b/test/integration_tests/analyze/grpc_dart_test.dart
@@ -18,20 +18,16 @@ void main() {
     });
 
     test(
-        "Detects 2 missing exports correctly (especially doesn't complain about 'ServerHandler')",
+        "Detects 1 missing exports correctly (especially doesn't complain about 'ServerHandler')",
         () {
       final rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests =
           packageApi.rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests
               .toList();
       expect(
-          rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests.length, 2);
+          rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests.length, 1);
       expect(
           rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests
               .any((decl) => decl.name == '\$1.Duration'),
-          isTrue);
-      expect(
-          rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests
-              .any((decl) => decl.name == 'Any'),
           isTrue);
       expect(
           rootDeclarationsWithoutEntryPointsAndVisibleOutsideTests

--- a/test/integration_tests/analyze/unexported_function_test.dart
+++ b/test/integration_tests/analyze/unexported_function_test.dart
@@ -1,0 +1,29 @@
+import 'package:dart_apitool/api_tool.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Unexported functions', () {
+    late PackageApiAnalyzer packageAnalyzer;
+    late PackageApi packageApi;
+    setUp(() async {
+      packageAnalyzer = PackageApiAnalyzer(
+        packagePath: 'test/test_packages/missing_export/package_a',
+      );
+      packageApi = await packageAnalyzer.analyze();
+    });
+
+    test('should not include unexported top level function', () {
+      final buildPublicClassExecutables = packageApi.executableDeclarations
+          .where((ed) => ed.name == 'buildPublicClass')
+          .toList();
+      expect(buildPublicClassExecutables, isEmpty);
+    });
+
+    test('should not include unexported PrivateClass', () {
+      final privateClassEntries = packageApi.interfaceDeclarations
+          .where((id) => id.name == 'PrivateClass')
+          .toList();
+      expect(privateClassEntries, isEmpty);
+    });
+  });
+}

--- a/test/test_packages/missing_export/package_a/lib/package_a.dart
+++ b/test/test_packages/missing_export/package_a/lib/package_a.dart
@@ -3,3 +3,4 @@ library package_a;
 export 'types/class_a.dart';
 export 'types/class_c.dart' show ClassC;
 export 'types/private_types.dart';
+export 'types/hidden_build_method.dart' show PublicClass;

--- a/test/test_packages/missing_export/package_a/lib/types/hidden_build_method.dart
+++ b/test/test_packages/missing_export/package_a/lib/types/hidden_build_method.dart
@@ -1,0 +1,12 @@
+/// PublicClass contains a [PrivateClass] field and a private constructor accepting it
+class PublicClass {
+  PrivateClass _privateClass;
+  const PublicClass._(this._privateClass);
+}
+
+/// this class is "private" (is not exported)
+class PrivateClass {}
+
+// build method uses a "PrivateClass" as an argument to build the PublicClass instance
+PublicClass buildPublicClass(PrivateClass privateClass) =>
+    PublicClass._(privateClass);


### PR DESCRIPTION
## Description
dart_apitool tracks show and hide export modifiers and checks if a type is exported before adding it to the public API model. 
This works for interface types but was not implemented for:
- top level functions
- top level variables
- aliases

fixes #220 

This PR adds the check to those places as well.
Turned out that one of our integration tests actually tested that wrong behavior by accident

## Type of Change
<!--- Put an 'x' in all boxes which apply -->

- [ ] 🚀 New feature (non-breaking change)
- [x] 🛠️ Bug fix (non-breaking change)
- [ ] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
