### PR TITLE
tech: use package_config for package config interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix: naming of unary operators was wrong (unaryunary...)
 - fix: handling of top level functions in the context of show / hide in exports
 - fix: report type parameter change in a base class as new change kind instead of removal + addition of base classes
+- fix: handling of relative package paths
 
 ## Version 0.22.0
 - fix: Fixes an issue if we have to deal with two types with the same name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.23
+- technical: use package_config to interact with package configs
+
 ## Version 0.22.1
 - feat: Support git references for package analysis
   - Supports both HTTPS and SSH git repository formats

--- a/lib/src/cli/commands/command_mixin.dart
+++ b/lib/src/cli/commands/command_mixin.dart
@@ -4,6 +4,7 @@ import 'package:args/args.dart';
 import 'package:dart_apitool/api_tool.dart';
 import 'package:dart_apitool/src/cli/source_item.dart';
 import 'package:path/path.dart' as p;
+import 'package:package_config/package_config.dart' as package_config;
 
 import '../git_ref.dart';
 import '../package_ref.dart';
@@ -221,13 +222,12 @@ OBSOLETE: Has no effect anymore.
       await analysisOptionsFile.delete();
     }
 
+    final packageConfig =
+        await package_config.findPackageConfig(Directory(packagePath));
+
     // Check if the package_config.json is already present from the preparation step
-    final packageConfig = File(DartInteraction.getPackageConfigPathForPackage(
-      packagePath,
-      stdoutSession: stdoutSession,
-      doCheckWorkspace: true,
-    ));
-    if (!packageConfig.existsSync()) {
+
+    if (packageConfig == null) {
       await stdoutSession.writeln('Running pub get');
       await PubInteraction.runPubGetIndirectly(
         packagePath,

--- a/lib/src/tooling/dart_interaction.dart
+++ b/lib/src/tooling/dart_interaction.dart
@@ -133,6 +133,12 @@ abstract class DartInteraction {
       String newPackageName
     })? packageNameReplacementInfo,
   }) async {
+    if (path.isRelative(fromPackage)) {
+      fromPackage = path.absolute(fromPackage);
+    }
+    if (path.isRelative(toPackage)) {
+      toPackage = path.absolute(toPackage);
+    }
     final fromPackageConfigPath = getPackageConfigPathForPackage(fromPackage,
         stdoutSession: stdoutSession, doCheckWorkspace: true);
     final toPackageConfigPath = getPackageConfigPathForPackage(toPackage,

--- a/lib/src/tooling/dart_interaction.dart
+++ b/lib/src/tooling/dart_interaction.dart
@@ -2,11 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:lumberdash/lumberdash.dart';
 import 'package:pubspec_manager/pubspec_manager.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:path/path.dart' as path;
+
+import 'package:package_config/package_config.dart' as package_config;
 
 import '../errors/errors.dart';
 import '../utils/utils.dart';
@@ -83,47 +84,6 @@ abstract class DartInteraction {
         stdoutSession: stdoutSession);
   }
 
-  static String getPackageConfigPathForPackage(
-    String packagePath, {
-    required StdoutSession stdoutSession,
-    required bool doCheckWorkspace,
-  }) {
-    String packageConfigPackagePath = packagePath;
-    final packageDir = Directory(packagePath);
-    if (doCheckWorkspace && packageDir.existsSync()) {
-      // if the package directory exists (source) then we check if we have to deal with a workspace
-      try {
-        final pubspec = PubSpec.load(directory: packagePath);
-        final resolutionSection =
-            pubspec.document.findSectionForKey('resolution');
-        if (!resolutionSection.missing) {
-          bool resolvesWithWorkspace = false;
-          for (final line in resolutionSection.lines) {
-            if (line.text.contains('resolution:') &&
-                line.text.trim().endsWith('workspace')) {
-              resolvesWithWorkspace = true;
-              break;
-            }
-          }
-          if (resolvesWithWorkspace) {
-            final workspacePath = _findWorkspacePath(packagePath);
-            if (workspacePath == null) {
-              stdoutSession
-                  .writeln('Could not find workspace for package $packagePath');
-            } else {
-              packageConfigPackagePath = workspacePath;
-            }
-          }
-        }
-      } catch (e) {
-        stdoutSession
-            .writeln('Error loading pubspec.yaml, continuing anyways: $e');
-      }
-    }
-    return path.join(
-        packageConfigPackagePath, '.dart_tool', 'package_config.json');
-  }
-
   static Future transferPackageConfig({
     required String fromPackage,
     required String toPackage,
@@ -139,85 +99,38 @@ abstract class DartInteraction {
     if (path.isRelative(toPackage)) {
       toPackage = path.absolute(toPackage);
     }
-    final fromPackageConfigPath = getPackageConfigPathForPackage(fromPackage,
-        stdoutSession: stdoutSession, doCheckWorkspace: true);
-    final toPackageConfigPath = getPackageConfigPathForPackage(toPackage,
-        stdoutSession: stdoutSession, doCheckWorkspace: true);
-    Directory(path.dirname(toPackageConfigPath)).createSync(recursive: true);
-    File(toPackageConfigPath)
-        .writeAsStringSync(File(fromPackageConfigPath).readAsStringSync());
-    await _adaptPackageConfigToAbsolutePaths(
-      targetPackageConfigPath: toPackageConfigPath,
-      sourcePackageConfigPath: fromPackageConfigPath,
-      packageNameReplacementInfo: packageNameReplacementInfo,
-    );
-  }
 
-  static Future _adaptPackageConfigToAbsolutePaths({
-    required String targetPackageConfigPath,
-    required String sourcePackageConfigPath,
-    ({
-      String newPackageName,
-      String oldPackageName
-    })? packageNameReplacementInfo,
-  }) async {
-    final sourcePackageConfigDirPath = path.dirname(sourcePackageConfigPath);
-    final sourcePackageDirPath =
-        Directory(sourcePackageConfigDirPath).parent.path;
-    final targetPackageConfigContent =
-        jsonDecode(await File(targetPackageConfigPath).readAsString());
-    if (packageNameReplacementInfo != null) {
-      final packages = targetPackageConfigContent['packages'] as List;
-      packages.removeWhere((package) =>
-          package['name'] == packageNameReplacementInfo.newPackageName);
-      packages.singleWhereOrNull((package) =>
-              package['name'] ==
-              packageNameReplacementInfo.oldPackageName)?['name'] =
-          packageNameReplacementInfo.newPackageName;
+    final packageConfig =
+        await package_config.findPackageConfig(Directory(fromPackage));
+    if (packageConfig == null) {
+      throw Exception('No package config found for $fromPackage');
     }
-    // iterate through the package_config.json content and look for relative paths
-    for (final packageConfig in targetPackageConfigContent['packages']) {
-      final rootUri = Uri.parse(packageConfig['rootUri']);
-      final packagePath = path.fromUri(rootUri);
+    await package_config.savePackageConfig(packageConfig, Directory(toPackage));
 
-      if (path.isRelative(packagePath)) {
-        // we make the relative path absolute by using the origin of the source package config as a base
-        final normalizedAbsolutePackagePath = path.absolute(
-          path.normalize(path.join(sourcePackageConfigDirPath, packagePath)),
-        );
-        // if the relative path is the package path, then don't make it absolute
-        if (path.equals(sourcePackageDirPath, normalizedAbsolutePackagePath)) {
-          continue;
+    // now we need to replace all references to "fromPackage" with "toPackage"
+    // and apply potentially given package replacements
+    final packageConfigFile = File(
+      path.join(toPackage, '.dart_tool', 'package_config.json'),
+    );
+    if (!packageConfigFile.existsSync()) {
+      throw Exception('No package config file found for $toPackage');
+    }
+    final packageConfigContent = await packageConfigFile.readAsString();
+    final packageConfigJson = jsonDecode(packageConfigContent);
+    for (final packageEntry in packageConfigJson['packages']) {
+      final rootUri = Uri.parse(packageEntry['rootUri']);
+      if (rootUri.isScheme('file')) {
+        final rootPath = rootUri.toFilePath();
+        if (path.equals(fromPackage, rootPath)) {
+          packageEntry['rootUri'] = Uri.file(toPackage).toString();
         }
-        // and write the new absolute path back to the json structure
-        packageConfig['rootUri'] =
-            path.toUri(normalizedAbsolutePackagePath).toString();
+      }
+      if (packageNameReplacementInfo != null &&
+          packageEntry['name'] == packageNameReplacementInfo.oldPackageName) {
+        packageEntry['name'] = packageNameReplacementInfo.newPackageName;
       }
     }
-    final encoder = JsonEncoder.withIndent('    ');
-    // replace the package config with the new content
-    await File(targetPackageConfigPath).writeAsString(
-      encoder.convert(targetPackageConfigContent),
-      mode: FileMode.write,
-    );
-  }
-
-  static String? _findWorkspacePath(String packagePath) {
-    Directory currentDirectory = Directory(packagePath).parent;
-    while (currentDirectory.path != currentDirectory.parent.path) {
-      if (!File(path.join(currentDirectory.path, 'pubspec.yaml'))
-          .existsSync()) {
-        currentDirectory = currentDirectory.parent;
-        continue;
-      }
-      final pubspec = PubSpec.load(directory: currentDirectory.path);
-      if (pubspec.document.findSectionForKey('workspace').missing) {
-        currentDirectory = currentDirectory.parent;
-      } else {
-        return currentDirectory.path;
-      }
-    }
-    return null;
+    await packageConfigFile.writeAsString(jsonEncode(packageConfigJson));
   }
 
   static Future<String> _runDartOrFlutterCommand(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_apitool
 description: A tool to analyze the public API of a package, create a model of it and diff it against another version to check semver.
 repository: https://github.com/bmw-tech/dart_apitool
 
-version: 0.22.1-dev
+version: 0.23.0-dev
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -17,6 +17,7 @@ dependencies:
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   lumberdash: ^3.0.0
+  package_config: ^2.2.0
   path: ^1.9.0
   plist_parser: ^0.2.4
   pub_semver: ^2.1.4


### PR DESCRIPTION
## Description
This PR is based on #238 
It implements a suggestion from #237 to use the package_config to do the heavy lifting in dealing with package configs.
As we have some special cases (like running pub get from a temporary directory and manipulating the config afterwards and taking the config from one place and saving it to another) we still need to do some tweaking of the result.

Those changes have a quite high potential to affect the general functionality of dart_apitool so this is a breaking change.

## Type of Change

- [ ] 🚀 New feature (non-breaking change)
- [ ] 🛠️ Bug fix (non-breaking change)
- [x] ⚠️ Breaking change (feature or bug fix which breaks existing behaviors/APIs)
- [ ] 🏗️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore / Housekeeping
